### PR TITLE
Send statistics with publication contexts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ plugins {
 }
 
 group = 'com.github'
-version = "0.3.6"
+version = "0.3.7"
 
 compileJava {
     sourceCompatibility = '17'

--- a/src/main/java/com/github/checkit/dao/PublicationContextDao.java
+++ b/src/main/java/com/github/checkit/dao/PublicationContextDao.java
@@ -290,4 +290,138 @@ public class PublicationContextDao extends BaseDao<PublicationContext> {
             throw new PersistenceException(e);
         }
     }
+
+    /**
+     * Counts changes in specified publication context.
+     *
+     * @param publicationContextUri URI identifier of publication context
+     * @return number of changes
+     */
+    public Integer countChanges(URI publicationContextUri) {
+        Objects.requireNonNull(publicationContextUri);
+        try {
+            return em.createNativeQuery("SELECT (COUNT(DISTINCT ?change) as ?count) WHERE { "
+                    + "?pc a ?type ; "
+                    + "    ?hasChange ?change . "
+                    + "}", Integer.class)
+                .setParameter("type", typeUri)
+                .setParameter("pc", publicationContextUri)
+                .setParameter("hasChange", URI.create(TermVocabulary.s_p_ma_zmenu))
+                .setDescriptor(descriptorFactory.publicationContextDescriptor(publicationContextUri))
+                .getSingleResult();
+        } catch (RuntimeException e) {
+            throw new PersistenceException(e);
+        }
+    }
+
+    /**
+     * Counts changes reviewable by specified user in specified publication context.
+     *
+     * @param publicationContextUri URI identifier of publication context
+     * @param userUri               URI identifier of user
+     * @return number of changes
+     */
+    public Integer countReviewableChanges(URI publicationContextUri, URI userUri) {
+
+        try {
+            return em.createNativeQuery("SELECT (COUNT(DISTINCT ?change) as ?count) WHERE { "
+                    + "?pc a ?type ; "
+                    + "    ?hasChange ?change . "
+                    + "?change ?inContext ?ctx . "
+                    + "?ctx ?basedOn ?voc . "
+                    + "?voc ?gestoredBy ?user . "
+                    + "}", Integer.class)
+                .setParameter("type", typeUri)
+                .setParameter("pc", publicationContextUri)
+                .setParameter("hasChange", URI.create(TermVocabulary.s_p_ma_zmenu))
+                .setParameter("inContext", URI.create(TermVocabulary.s_p_v_kontextu))
+                .setParameter("basedOn", URI.create(TermVocabulary.s_p_vychazi_z_verze))
+                .setParameter("gestoredBy", URI.create(TermVocabulary.s_p_ma_gestora))
+                .setParameter("user", userUri)
+                .getSingleResult();
+        } catch (RuntimeException e) {
+            throw new PersistenceException(e);
+        }
+    }
+
+    /**
+     * Counts approved changes in specified publication context.
+     *
+     * @param publicationContextUri URI identifier of publication context
+     * @return number of changes
+     */
+    public Integer countApprovedChanges(URI publicationContextUri) {
+        Objects.requireNonNull(publicationContextUri);
+        try {
+            return em.createNativeQuery("SELECT (COUNT(DISTINCT ?change) as ?count) WHERE { "
+                    + "?pc a ?type ; "
+                    + "    ?hasChange ?change . "
+                    + "?change ?approvedBy ?user . "
+                    + "}", Integer.class)
+                .setParameter("type", typeUri)
+                .setParameter("pc", publicationContextUri)
+                .setParameter("hasChange", URI.create(TermVocabulary.s_p_ma_zmenu))
+                .setParameter("approvedBy", URI.create(TermVocabulary.s_p_schvaleno))
+                .setDescriptor(descriptorFactory.publicationContextDescriptor(publicationContextUri))
+                .getSingleResult();
+        } catch (RuntimeException e) {
+            throw new PersistenceException(e);
+        }
+    }
+
+    /**
+     * Counts changes approved by specified user in specified publication context.
+     *
+     * @param publicationContextUri URI identifier of publication context
+     * @param userUri               URI identifier of user
+     * @return number of changes
+     */
+    public Integer countApprovedChanges(URI publicationContextUri, URI userUri) {
+        Objects.requireNonNull(publicationContextUri);
+        Objects.requireNonNull(userUri);
+        try {
+            return em.createNativeQuery("SELECT (COUNT(DISTINCT ?change) as ?count) WHERE { "
+                    + "?pc a ?type ; "
+                    + "    ?hasChange ?change . "
+                    + "?change ?approvedBy ?user . "
+                    + "}", Integer.class)
+                .setParameter("type", typeUri)
+                .setParameter("pc", publicationContextUri)
+                .setParameter("hasChange", URI.create(TermVocabulary.s_p_ma_zmenu))
+                .setParameter("approvedBy", URI.create(TermVocabulary.s_p_schvaleno))
+                .setParameter("user", userUri)
+                .setDescriptor(descriptorFactory.publicationContextDescriptor(publicationContextUri))
+                .getSingleResult();
+        } catch (RuntimeException e) {
+            throw new PersistenceException(e);
+        }
+    }
+
+    /**
+     * Counts changes rejected by specified user in specified publication context.
+     *
+     * @param publicationContextUri URI identifier of publication context
+     * @param userUri               URI identifier of user
+     * @return number of changes
+     */
+    public Integer countRejectedChanges(URI publicationContextUri, URI userUri) {
+        Objects.requireNonNull(publicationContextUri);
+        Objects.requireNonNull(userUri);
+        try {
+            return em.createNativeQuery("SELECT (COUNT(DISTINCT ?change) as ?count) WHERE { "
+                    + "?pc a ?type ; "
+                    + "    ?hasChange ?change . "
+                    + "?change ?rejectedBy ?user . "
+                    + "}", Integer.class)
+                .setParameter("type", typeUri)
+                .setParameter("pc", publicationContextUri)
+                .setParameter("hasChange", URI.create(TermVocabulary.s_p_ma_zmenu))
+                .setParameter("rejectedBy", URI.create(TermVocabulary.s_p_zamitnuto))
+                .setParameter("user", userUri)
+                .setDescriptor(descriptorFactory.publicationContextDescriptor(publicationContextUri))
+                .getSingleResult();
+        } catch (RuntimeException e) {
+            throw new PersistenceException(e);
+        }
+    }
 }

--- a/src/main/java/com/github/checkit/dao/PublicationContextDao.java
+++ b/src/main/java/com/github/checkit/dao/PublicationContextDao.java
@@ -315,6 +315,35 @@ public class PublicationContextDao extends BaseDao<PublicationContext> {
     }
 
     /**
+     * Counts changes in specified publication context in specified vocabulary.
+     *
+     * @param publicationContextUri URI identifier of publication context
+     * @param vocabularyUri         URI identifier of vocabulary
+     * @return number of changes
+     */
+    public Integer countChangesInVocabulary(URI publicationContextUri, URI vocabularyUri) {
+        Objects.requireNonNull(publicationContextUri);
+        Objects.requireNonNull(vocabularyUri);
+        try {
+            return em.createNativeQuery("SELECT (COUNT(DISTINCT ?change) as ?count) WHERE { "
+                    + "?pc a ?type ; "
+                    + "    ?hasChange ?change . "
+                    + "?change ?inContext ?ctx . "
+                    + "?ctx ?basedOn ?voc . "
+                    + "}", Integer.class)
+                .setParameter("type", typeUri)
+                .setParameter("pc", publicationContextUri)
+                .setParameter("hasChange", URI.create(TermVocabulary.s_p_ma_zmenu))
+                .setParameter("inContext", URI.create(TermVocabulary.s_p_v_kontextu))
+                .setParameter("basedOn", URI.create(TermVocabulary.s_p_vychazi_z_verze))
+                .setParameter("voc", vocabularyUri)
+                .getSingleResult();
+        } catch (RuntimeException e) {
+            throw new PersistenceException(e);
+        }
+    }
+
+    /**
      * Counts changes reviewable by specified user in specified publication context.
      *
      * @param publicationContextUri URI identifier of publication context
@@ -322,7 +351,8 @@ public class PublicationContextDao extends BaseDao<PublicationContext> {
      * @return number of changes
      */
     public Integer countReviewableChanges(URI publicationContextUri, URI userUri) {
-
+        Objects.requireNonNull(publicationContextUri);
+        Objects.requireNonNull(userUri);
         try {
             return em.createNativeQuery("SELECT (COUNT(DISTINCT ?change) as ?count) WHERE { "
                     + "?pc a ?type ; "
@@ -398,6 +428,40 @@ public class PublicationContextDao extends BaseDao<PublicationContext> {
     }
 
     /**
+     * Counts changes approved by specified user in specified publication context in specified vocabulary.
+     *
+     * @param publicationContextUri URI identifier of publication context
+     * @param userUri               URI identifier of user
+     * @param vocabularyUri         URI identifier of vocabulary
+     * @return number of changes
+     */
+    public Integer countApprovedChangesInVocabulary(URI publicationContextUri, URI userUri, URI vocabularyUri) {
+        Objects.requireNonNull(publicationContextUri);
+        Objects.requireNonNull(userUri);
+        Objects.requireNonNull(vocabularyUri);
+        try {
+            return em.createNativeQuery("SELECT (COUNT(DISTINCT ?change) as ?count) WHERE { "
+                    + "?pc a ?type ; "
+                    + "    ?hasChange ?change . "
+                    + "?change ?approvedBy ?user ; "
+                    + "        ?inContext ?ctx . "
+                    + "?ctx ?basedOn ?voc . "
+                    + "}", Integer.class)
+                .setParameter("type", typeUri)
+                .setParameter("pc", publicationContextUri)
+                .setParameter("hasChange", URI.create(TermVocabulary.s_p_ma_zmenu))
+                .setParameter("approvedBy", URI.create(TermVocabulary.s_p_schvaleno))
+                .setParameter("user", userUri)
+                .setParameter("inContext", URI.create(TermVocabulary.s_p_v_kontextu))
+                .setParameter("basedOn", URI.create(TermVocabulary.s_p_vychazi_z_verze))
+                .setParameter("voc", vocabularyUri)
+                .getSingleResult();
+        } catch (RuntimeException e) {
+            throw new PersistenceException(e);
+        }
+    }
+
+    /**
      * Counts changes rejected by specified user in specified publication context.
      *
      * @param publicationContextUri URI identifier of publication context
@@ -419,6 +483,40 @@ public class PublicationContextDao extends BaseDao<PublicationContext> {
                 .setParameter("rejectedBy", URI.create(TermVocabulary.s_p_zamitnuto))
                 .setParameter("user", userUri)
                 .setDescriptor(descriptorFactory.publicationContextDescriptor(publicationContextUri))
+                .getSingleResult();
+        } catch (RuntimeException e) {
+            throw new PersistenceException(e);
+        }
+    }
+
+    /**
+     * Counts changes rejected by specified user in specified publication context in specified vocabulary.
+     *
+     * @param publicationContextUri URI identifier of publication context
+     * @param userUri               URI identifier of user
+     * @param vocabularyUri         URI identifier of vocabulary
+     * @return number of changes
+     */
+    public Integer countRejectedChangesInVocabulary(URI publicationContextUri, URI userUri, URI vocabularyUri) {
+        Objects.requireNonNull(publicationContextUri);
+        Objects.requireNonNull(userUri);
+        Objects.requireNonNull(vocabularyUri);
+        try {
+            return em.createNativeQuery("SELECT (COUNT(DISTINCT ?change) as ?count) WHERE { "
+                    + "?pc a ?type ; "
+                    + "    ?hasChange ?change . "
+                    + "?change ?rejectedBy ?user ; "
+                    + "        ?inContext ?ctx . "
+                    + "?ctx ?basedOn ?voc . "
+                    + "}", Integer.class)
+                .setParameter("type", typeUri)
+                .setParameter("pc", publicationContextUri)
+                .setParameter("hasChange", URI.create(TermVocabulary.s_p_ma_zmenu))
+                .setParameter("rejectedBy", URI.create(TermVocabulary.s_p_zamitnuto))
+                .setParameter("user", userUri)
+                .setParameter("inContext", URI.create(TermVocabulary.s_p_v_kontextu))
+                .setParameter("basedOn", URI.create(TermVocabulary.s_p_vychazi_z_verze))
+                .setParameter("voc", vocabularyUri)
                 .getSingleResult();
         } catch (RuntimeException e) {
             throw new PersistenceException(e);

--- a/src/main/java/com/github/checkit/dto/PublicationContextDetailDto.java
+++ b/src/main/java/com/github/checkit/dto/PublicationContextDetailDto.java
@@ -14,8 +14,9 @@ public class PublicationContextDetailDto extends PublicationContextDto {
      * Constructor.
      */
     public PublicationContextDetailDto(PublicationContext publicationContext, PublicationContextState state,
-                                       CommentDto finalComment, List<ReviewableVocabularyDto> affectedVocabularies) {
-        super(publicationContext, state, finalComment);
+                                       CommentDto finalComment, PublicationContextStatisticsDto statistics,
+                                       List<ReviewableVocabularyDto> affectedVocabularies) {
+        super(publicationContext, state, finalComment, statistics);
         this.affectedVocabularies = affectedVocabularies;
     }
 }

--- a/src/main/java/com/github/checkit/dto/PublicationContextDto.java
+++ b/src/main/java/com/github/checkit/dto/PublicationContextDto.java
@@ -16,6 +16,8 @@ public class PublicationContextDto {
     private final PublicationContextState state;
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private final CommentDto finalComment;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private PublicationContextStatisticsDto statistics;
 
     /**
      * Constructor.
@@ -28,5 +30,15 @@ public class PublicationContextDto {
         this.projectContext = publicationContext.getFromProject().getUri();
         this.state = state;
         this.finalComment = finalComment;
+    }
+
+    /**
+     * Constructor.
+     */
+    public PublicationContextDto(PublicationContext publicationContext, PublicationContextState state,
+                                 CommentDto finalComment,
+                                 PublicationContextStatisticsDto statistics) {
+        this(publicationContext, state, finalComment);
+        this.statistics = statistics;
     }
 }

--- a/src/main/java/com/github/checkit/dto/PublicationContextStatisticsDto.java
+++ b/src/main/java/com/github/checkit/dto/PublicationContextStatisticsDto.java
@@ -1,0 +1,22 @@
+package com.github.checkit.dto;
+
+import lombok.Getter;
+
+@Getter
+public class PublicationContextStatisticsDto {
+    private final int totalChanges;
+    private final int reviewableChanges;
+    private final int approvedChanges;
+    private final int rejectedChanges;
+
+    /**
+     * Constructor.
+     */
+    public PublicationContextStatisticsDto(int totalChanges, int reviewableChanges, int approvedChanges,
+                                           int rejectedChanges) {
+        this.totalChanges = totalChanges;
+        this.reviewableChanges = reviewableChanges;
+        this.approvedChanges = approvedChanges;
+        this.rejectedChanges = rejectedChanges;
+    }
+}

--- a/src/main/java/com/github/checkit/dto/ReviewableVocabularyDto.java
+++ b/src/main/java/com/github/checkit/dto/ReviewableVocabularyDto.java
@@ -1,5 +1,6 @@
 package com.github.checkit.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.github.checkit.model.Vocabulary;
 import java.net.URI;
 import java.util.List;
@@ -11,15 +12,18 @@ public class ReviewableVocabularyDto {
     private final URI uri;
     private final String label;
     private final boolean gestored;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private final VocabularyStatisticsDto statistics;
     private final List<UserDto> gestors;
 
     /**
      * Constructor.
      */
-    public ReviewableVocabularyDto(Vocabulary vocabulary, boolean gestored) {
+    public ReviewableVocabularyDto(Vocabulary vocabulary, boolean gestored, VocabularyStatisticsDto statistics) {
         this.uri = vocabulary.getUri();
         this.label = vocabulary.getLabel();
         this.gestored = gestored;
         this.gestors = vocabulary.getGestors().stream().map(UserDto::new).toList();
+        this.statistics = statistics;
     }
 }

--- a/src/main/java/com/github/checkit/dto/VocabularyStatisticsDto.java
+++ b/src/main/java/com/github/checkit/dto/VocabularyStatisticsDto.java
@@ -1,0 +1,20 @@
+package com.github.checkit.dto;
+
+import lombok.Getter;
+
+@Getter
+public class VocabularyStatisticsDto {
+
+    private final int totalChanges;
+    private final int approvedChanges;
+    private final int rejectedChanges;
+
+    /**
+     * Constructor.
+     */
+    public VocabularyStatisticsDto(int totalChanges, int approvedChanges, int rejectedChanges) {
+        this.totalChanges = totalChanges;
+        this.approvedChanges = approvedChanges;
+        this.rejectedChanges = rejectedChanges;
+    }
+}

--- a/src/main/java/com/github/checkit/service/PublicationContextService.java
+++ b/src/main/java/com/github/checkit/service/PublicationContextService.java
@@ -186,7 +186,7 @@ public class PublicationContextService extends BaseRepositoryService<Publication
         User current = userService.getCurrent();
         URI publicationContextUri = createPublicationContextUriFromId(publicationContextId);
         boolean isAllowedToReview =
-            publicationContextDao.doesUserHavePermissionToReviewVocabulary(current.getUri(), publicationContextUri,
+            publicationContextDao.isUserHavePermittedToReviewVocabulary(current.getUri(), publicationContextUri,
                 vocabularyUri);
 
         PublicationContext pc = findRequired(publicationContextUri);


### PR DESCRIPTION
## Modified endpoints

GET `/publication-contexts/reviewable`
Now sends statistics, example:
```json
{
    "id": "instance1547112515",
    "uri": "https://slovník.gov.cz/datový/popis-zmen/pojem/publikační-kontext/instance1547112515",
    "label": "440-test2",
    "projectContext": "https://slovník.gov.cz/datový/pracovní-prostor/pojem/metadatový-kontext/instance-1942857069",
    "state": "CREATED",
    "statistics": {
        "totalChanges": 173,
        "reviewableChanges": 173,
        "approvedChanges": 10,
        "rejectedChanges": 1
    }
}
```

GET `/publication-contexts/{{Publication_ID}}`
Now sends statistics and vocabulary statistics, example:

```json
{
    "id": "instance1547112515",
    "uri": "https://slovník.gov.cz/datový/popis-zmen/pojem/publikační-kontext/instance1547112515",
    "label": "440-test2",
    "projectContext": "https://slovník.gov.cz/datový/pracovní-prostor/pojem/metadatový-kontext/instance-1942857069",
    "state": "CREATED",
    "statistics": {
        "totalChanges": 173,
        "reviewableChanges": 173,
        "approvedChanges": 10,
        "rejectedChanges": 1
    },
    "affectedVocabularies": [
        {
            "uri": "https://slovník.gov.cz/datový/440-test",
            "label": "440-test",
            "gestored": true,
            "statistics": {
                "totalChanges": 173,
                "approvedChanges": 10,
                "rejectedChanges": 1
            },
            "gestors": [...]
        }
    ]
}
```
