### PR TITLE
Check PC up-to-date when reviewing change

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ plugins {
 }
 
 group = 'com.github'
-version = "0.3.7"
+version = "0.3.8"
 
 compileJava {
     sourceCompatibility = '17'

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
 
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.0.4'
+    id 'org.springframework.boot' version '3.0.5'
     id 'io.spring.dependency-management' version '1.1.0'
     id 'io.freefair.aspectj.post-compile-weaving' version '6.6.3'
     id 'checkstyle'

--- a/src/main/java/com/github/checkit/controller/ChangeController.java
+++ b/src/main/java/com/github/checkit/controller/ChangeController.java
@@ -2,6 +2,7 @@ package com.github.checkit.controller;
 
 import com.github.checkit.service.ChangeService;
 import java.net.URI;
+import java.time.Instant;
 import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -9,6 +10,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -25,37 +27,37 @@ public class ChangeController extends BaseController {
 
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @PostMapping("/{changeId}/approved")
-    public void approveChange(@PathVariable String changeId) {
-        changeService.approveChange(changeId);
+    public void approveChange(@PathVariable String changeId, @RequestParam Instant versionDate) {
+        changeService.approveChange(changeId, versionDate);
     }
 
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @PostMapping("/approved")
-    public void approveChanges(@RequestBody List<URI> changes) {
-        changeService.approveChanges(changes);
+    public void approveChanges(@RequestBody List<URI> changes, @RequestParam Instant versionDate) {
+        changeService.approveChanges(changes, versionDate);
     }
 
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @PostMapping("/{changeId}/rejected")
-    public void rejectChange(@PathVariable String changeId) {
-        changeService.rejectChange(changeId);
+    public void rejectChange(@PathVariable String changeId, @RequestParam Instant versionDate) {
+        changeService.rejectChange(changeId, versionDate);
     }
 
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @PostMapping("/rejected")
-    public void rejectChanges(@RequestBody List<URI> changes) {
-        changeService.rejectChanges(changes);
+    public void rejectChanges(@RequestBody List<URI> changes, @RequestParam Instant versionDate) {
+        changeService.rejectChanges(changes, versionDate);
     }
 
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @DeleteMapping("/{changeId}/review")
-    public void removeChangeReview(@PathVariable String changeId) {
-        changeService.removeChangeReview(changeId);
+    public void removeChangeReview(@PathVariable String changeId, @RequestParam Instant versionDate) {
+        changeService.removeChangeReview(changeId, versionDate);
     }
 
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @DeleteMapping("/review")
-    public void removeChangesReview(@RequestBody List<URI> changes) {
-        changeService.removeChangesReview(changes);
+    public void removeChangesReview(@RequestBody List<URI> changes, @RequestParam Instant versionDate) {
+        changeService.removeChangesReview(changes, versionDate);
     }
 }

--- a/src/main/java/com/github/checkit/dto/ContextChangesDto.java
+++ b/src/main/java/com/github/checkit/dto/ContextChangesDto.java
@@ -1,7 +1,9 @@
 package com.github.checkit.dto;
 
 import com.github.checkit.dto.auxiliary.PublicationContextState;
+import com.github.checkit.model.PublicationContext;
 import java.net.URI;
+import java.time.Instant;
 import java.util.List;
 import lombok.Getter;
 
@@ -13,19 +15,21 @@ public class ContextChangesDto {
     private final boolean gestored;
     private final String publicationId;
     private final String publicationLabel;
+    private final Instant publicationLastUpdate;
     private final PublicationContextState publicationState;
     private final List<ChangeDto> changes;
 
     /**
      * Constructor.
      */
-    public ContextChangesDto(URI uri, String label, boolean gestored, String publicationId, String publicationLabel,
+    public ContextChangesDto(URI uri, String label, boolean gestored, PublicationContext pc,
                              PublicationContextState publicationState, List<ChangeDto> changes) {
         this.uri = uri;
         this.label = label;
         this.gestored = gestored;
-        this.publicationId = publicationId;
-        this.publicationLabel = publicationLabel;
+        this.publicationId = pc.getId();
+        this.publicationLabel = pc.getFromProject().getLabel();
+        this.publicationLastUpdate = pc.getModified();
         this.publicationState = publicationState;
         this.changes = changes;
     }

--- a/src/main/java/com/github/checkit/exception/EmptyArrayParameterException.java
+++ b/src/main/java/com/github/checkit/exception/EmptyArrayParameterException.java
@@ -1,0 +1,12 @@
+package com.github.checkit.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.BAD_REQUEST)
+public class EmptyArrayParameterException extends BaseException {
+
+    public EmptyArrayParameterException(String message, Object... args) {
+        super(message, args);
+    }
+}

--- a/src/main/java/com/github/checkit/exception/PublicationContextWasUpdatedException.java
+++ b/src/main/java/com/github/checkit/exception/PublicationContextWasUpdatedException.java
@@ -1,0 +1,18 @@
+package com.github.checkit.exception;
+
+import java.net.URI;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(value = HttpStatus.CONFLICT)
+public class PublicationContextWasUpdatedException extends BaseException {
+
+    public PublicationContextWasUpdatedException(String message, Object... args) {
+        super(message, args);
+    }
+
+    public static PublicationContextWasUpdatedException create(URI changeUri) {
+        return new PublicationContextWasUpdatedException("Publication context of change \"%s\" was updated, load new "
+            + "changes.", changeUri);
+    }
+}

--- a/src/main/java/com/github/checkit/service/ChangeService.java
+++ b/src/main/java/com/github/checkit/service/ChangeService.java
@@ -3,9 +3,11 @@ package com.github.checkit.service;
 import com.github.checkit.dao.BaseDao;
 import com.github.checkit.dao.ChangeDao;
 import com.github.checkit.dao.CommentDao;
+import com.github.checkit.exception.EmptyArrayParameterException;
 import com.github.checkit.exception.ForbiddenException;
 import com.github.checkit.exception.NotFoundException;
 import com.github.checkit.exception.PublicationContextIsClosedException;
+import com.github.checkit.exception.PublicationContextWasUpdatedException;
 import com.github.checkit.model.Change;
 import com.github.checkit.model.User;
 import com.github.checkit.model.VocabularyContext;
@@ -13,6 +15,7 @@ import com.github.checkit.model.auxilary.AbstractChangeableContext;
 import com.github.checkit.service.auxiliary.ChangeResolver;
 import com.github.checkit.util.TermVocabulary;
 import java.net.URI;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.jena.rdf.model.Model;
@@ -52,13 +55,15 @@ public class ChangeService extends BaseRepositoryService<Change> {
     /**
      * Marks specified change as approved by current user.
      *
-     * @param changeId identifier of change
+     * @param changeId    identifier of change
+     * @param versionDate date of publication context last update
      */
     @Transactional
-    public void approveChange(String changeId) {
+    public void approveChange(String changeId, Instant versionDate) {
         User current = userService.getCurrent();
         URI changeUri = createChangeUriFromId(changeId);
         checkUserCanReviewChange(current.getUri(), changeUri);
+        checkUpToDate(changeUri, versionDate);
         Change change = findRequired(changeUri);
         change.addApprovedBy(current);
         change.removeRejectedBy(current);
@@ -69,12 +74,17 @@ public class ChangeService extends BaseRepositoryService<Change> {
     /**
      * Marks specified list of changes as approved by current user.
      *
-     * @param changeUris URI identifiers of changes
+     * @param changeUris  URI identifiers of changes
+     * @param versionDate date of publication context last update
      */
     @Transactional
-    public void approveChanges(List<URI> changeUris) {
+    public void approveChanges(List<URI> changeUris, Instant versionDate) {
         User current = userService.getCurrent();
+        if (changeUris.isEmpty()) {
+            throw new EmptyArrayParameterException("List of changes to approve can't be empty.");
+        }
         changeUris.forEach(changeUri -> checkUserCanReviewChange(current.getUri(), changeUri));
+        checkUpToDate(changeUris.get(0), versionDate);
         for (URI changeUri : changeUris) {
             Change change = findRequired(changeUri);
             change.addApprovedBy(current);
@@ -87,13 +97,15 @@ public class ChangeService extends BaseRepositoryService<Change> {
     /**
      * Marks specified change as approved by current user.
      *
-     * @param changeId identifier of change
+     * @param changeId    identifier of change
+     * @param versionDate date of publication context last update
      */
     @Transactional
-    public void rejectChange(String changeId) {
+    public void rejectChange(String changeId, Instant versionDate) {
         User current = userService.getCurrent();
         URI changeUri = createChangeUriFromId(changeId);
         checkUserCanReviewChange(current.getUri(), changeUri);
+        checkUpToDate(changeUri, versionDate);
         Change change = findRequired(changeUri);
         change.addRejectedBy(current);
         change.removeApprovedBy(current);
@@ -104,12 +116,17 @@ public class ChangeService extends BaseRepositoryService<Change> {
     /**
      * Marks specified list of changes as rejected by current user.
      *
-     * @param changeUris URI identifiers of changes
+     * @param changeUris  URI identifiers of changes
+     * @param versionDate date of publication context last update
      */
     @Transactional
-    public void rejectChanges(List<URI> changeUris) {
+    public void rejectChanges(List<URI> changeUris, Instant versionDate) {
         User current = userService.getCurrent();
+        if (changeUris.isEmpty()) {
+            throw new EmptyArrayParameterException("List of changes to reject can't be empty.");
+        }
         changeUris.forEach(changeUri -> checkUserCanReviewChange(current.getUri(), changeUri));
+        checkUpToDate(changeUris.get(0), versionDate);
         for (URI changeUri : changeUris) {
             Change change = findRequired(changeUri);
             change.addRejectedBy(current);
@@ -122,13 +139,15 @@ public class ChangeService extends BaseRepositoryService<Change> {
     /**
      * Clears current user's review on specified change.
      *
-     * @param changeId identifier of change
+     * @param changeId    identifier of change
+     * @param versionDate date of publication context last update
      */
     @Transactional
-    public void removeChangeReview(String changeId) {
+    public void removeChangeReview(String changeId, Instant versionDate) {
         User current = userService.getCurrent();
         URI changeUri = createChangeUriFromId(changeId);
         checkUserCanReviewChange(current.getUri(), changeUri);
+        checkUpToDate(changeUri, versionDate);
         Change change = findRequired(changeUri);
         change.removeRejectedBy(current);
         change.removeApprovedBy(current);
@@ -140,12 +159,17 @@ public class ChangeService extends BaseRepositoryService<Change> {
     /**
      * Clears current user's review on specified list of changes.
      *
-     * @param changeUris URI identifiers of changes
+     * @param changeUris  URI identifiers of changes
+     * @param versionDate date of publication context last update
      */
     @Transactional
-    public void removeChangesReview(List<URI> changeUris) {
+    public void removeChangesReview(List<URI> changeUris, Instant versionDate) {
         User current = userService.getCurrent();
+        if (changeUris.isEmpty()) {
+            throw new EmptyArrayParameterException("List of changes to clear review can't be empty.");
+        }
         changeUris.forEach(changeUri -> checkUserCanReviewChange(current.getUri(), changeUri));
+        checkUpToDate(changeUris.get(0), versionDate);
         for (URI changeUri : changeUris) {
             Change change = findRequired(changeUri);
             change.removeRejectedBy(current);
@@ -206,6 +230,12 @@ public class ChangeService extends BaseRepositoryService<Change> {
     private void checkNotInClosedPublicationContext(URI changeUri) {
         if (changeDao.isChangesPublicationContextClosed(changeUri)) {
             throw PublicationContextIsClosedException.create(changeUri);
+        }
+    }
+
+    private void checkUpToDate(URI changeUri, Instant versionDate) {
+        if (changeDao.wasChangesPublicationContextUpdated(changeUri, versionDate)) {
+            throw PublicationContextWasUpdatedException.create(changeUri);
         }
     }
 

--- a/src/main/java/com/github/checkit/service/PublicationContextService.java
+++ b/src/main/java/com/github/checkit/service/PublicationContextService.java
@@ -192,8 +192,8 @@ public class PublicationContextService extends BaseRepositoryService<Publication
         PublicationContext pc = findRequired(publicationContextUri);
         String vocabularyLabel = vocabularyService.findRequired(vocabularyUri).getLabel();
         List<ChangeDto> changes = convertPublicationChangesToDtos(pc, current, language, vocabularyUri);
-        return new ContextChangesDto(vocabularyUri, vocabularyLabel, isAllowedToReview, pc.getId(),
-            pc.getFromProject().getLabel(), getState(pc, null), changes);
+        return new ContextChangesDto(vocabularyUri, vocabularyLabel, isAllowedToReview, pc, getState(pc, null),
+            changes);
     }
 
     /**


### PR DESCRIPTION
## Modified endpoints 

Endpint GET `/publication-contexts/{publicationContextId}/vocabulary-changes` now returns var `publicationLastUpdate`, example: 

```json
{
    "uri": "https://slovník.gov.cz/datový/440-test",
    "label": "440-test",
    "gestored": true,
    "publicationId": "instance1547112515",
    "publicationLabel": "440-test2",
    "publicationLastUpdate": "2023-04-19T08:54:43.249Z",
    "publicationState": "CREATED",
    "changes": [...]
}
```

Following endpoints, now require parameter `versionDate` (date example `2023-04-19T08:54:43.249Z`):
*If `versionDate` does not match PC `modifiedDate` in DB 409 Conflict is returned.*
- POST `/changes/{changeId}/approved`
- POST `/changes/approved`
- POST `/changes/{changeId}/rejected`
- POST `/changes/rejected`
- DELETE `/changes/{changeId}/review`
- DELETE `/changes/review`