### PR TITLE
Correction of counting statistics

### DIFF
--- a/src/main/java/com/github/checkit/dao/PublicationContextDao.java
+++ b/src/main/java/com/github/checkit/dao/PublicationContextDao.java
@@ -303,10 +303,13 @@ public class PublicationContextDao extends BaseDao<PublicationContext> {
             return em.createNativeQuery("SELECT (COUNT(DISTINCT ?change) as ?count) WHERE { "
                     + "?pc a ?type ; "
                     + "    ?hasChange ?change . "
+                    + "?change ?countable ?true . "
                     + "}", Integer.class)
                 .setParameter("type", typeUri)
                 .setParameter("pc", publicationContextUri)
                 .setParameter("hasChange", URI.create(TermVocabulary.s_p_ma_zmenu))
+                .setParameter("countable", URI.create(TermVocabulary.s_p_je_pocitatelna_do_statistiky))
+                .setParameter("true", true)
                 .setDescriptor(descriptorFactory.publicationContextDescriptor(publicationContextUri))
                 .getSingleResult();
         } catch (RuntimeException e) {
@@ -328,13 +331,16 @@ public class PublicationContextDao extends BaseDao<PublicationContext> {
             return em.createNativeQuery("SELECT (COUNT(DISTINCT ?change) as ?count) WHERE { "
                     + "?pc a ?type ; "
                     + "    ?hasChange ?change . "
-                    + "?change ?inContext ?ctx . "
+                    + "?change ?inContext ?ctx ; "
+                    + "        ?countable ?true . "
                     + "?ctx ?basedOn ?voc . "
                     + "}", Integer.class)
                 .setParameter("type", typeUri)
                 .setParameter("pc", publicationContextUri)
                 .setParameter("hasChange", URI.create(TermVocabulary.s_p_ma_zmenu))
                 .setParameter("inContext", URI.create(TermVocabulary.s_p_v_kontextu))
+                .setParameter("countable", URI.create(TermVocabulary.s_p_je_pocitatelna_do_statistiky))
+                .setParameter("true", true)
                 .setParameter("basedOn", URI.create(TermVocabulary.s_p_vychazi_z_verze))
                 .setParameter("voc", vocabularyUri)
                 .getSingleResult();
@@ -357,7 +363,8 @@ public class PublicationContextDao extends BaseDao<PublicationContext> {
             return em.createNativeQuery("SELECT (COUNT(DISTINCT ?change) as ?count) WHERE { "
                     + "?pc a ?type ; "
                     + "    ?hasChange ?change . "
-                    + "?change ?inContext ?ctx . "
+                    + "?change ?inContext ?ctx ; "
+                    + "        ?countable ?true . "
                     + "?ctx ?basedOn ?voc . "
                     + "?voc ?gestoredBy ?user . "
                     + "}", Integer.class)
@@ -365,6 +372,8 @@ public class PublicationContextDao extends BaseDao<PublicationContext> {
                 .setParameter("pc", publicationContextUri)
                 .setParameter("hasChange", URI.create(TermVocabulary.s_p_ma_zmenu))
                 .setParameter("inContext", URI.create(TermVocabulary.s_p_v_kontextu))
+                .setParameter("countable", URI.create(TermVocabulary.s_p_je_pocitatelna_do_statistiky))
+                .setParameter("true", true)
                 .setParameter("basedOn", URI.create(TermVocabulary.s_p_vychazi_z_verze))
                 .setParameter("gestoredBy", URI.create(TermVocabulary.s_p_ma_gestora))
                 .setParameter("user", userUri)
@@ -386,12 +395,15 @@ public class PublicationContextDao extends BaseDao<PublicationContext> {
             return em.createNativeQuery("SELECT (COUNT(DISTINCT ?change) as ?count) WHERE { "
                     + "?pc a ?type ; "
                     + "    ?hasChange ?change . "
-                    + "?change ?approvedBy ?user . "
+                    + "?change ?approvedBy ?user ; "
+                    + "        ?countable ?true . "
                     + "}", Integer.class)
                 .setParameter("type", typeUri)
                 .setParameter("pc", publicationContextUri)
                 .setParameter("hasChange", URI.create(TermVocabulary.s_p_ma_zmenu))
                 .setParameter("approvedBy", URI.create(TermVocabulary.s_p_schvaleno))
+                .setParameter("countable", URI.create(TermVocabulary.s_p_je_pocitatelna_do_statistiky))
+                .setParameter("true", true)
                 .setDescriptor(descriptorFactory.publicationContextDescriptor(publicationContextUri))
                 .getSingleResult();
         } catch (RuntimeException e) {
@@ -455,13 +467,16 @@ public class PublicationContextDao extends BaseDao<PublicationContext> {
             return em.createNativeQuery("SELECT (COUNT(DISTINCT ?change) as ?count) WHERE { "
                     + "?pc a ?type ; "
                     + "    ?hasChange ?change . "
-                    + "?change ?reviewedBy ?user . "
+                    + "?change ?reviewedBy ?user ; "
+                    + "        ?countable ?true . "
                     + "}", Integer.class)
                 .setParameter("type", typeUri)
                 .setParameter("pc", publicationContextUri)
                 .setParameter("hasChange", URI.create(TermVocabulary.s_p_ma_zmenu))
                 .setParameter("reviewedBy", reviewRelationUri)
                 .setParameter("user", userUri)
+                .setParameter("countable", URI.create(TermVocabulary.s_p_je_pocitatelna_do_statistiky))
+                .setParameter("true", true)
                 .setDescriptor(descriptorFactory.publicationContextDescriptor(publicationContextUri))
                 .getSingleResult();
         } catch (RuntimeException e) {
@@ -480,7 +495,8 @@ public class PublicationContextDao extends BaseDao<PublicationContext> {
                     + "?pc a ?type ; "
                     + "    ?hasChange ?change . "
                     + "?change ?reviewedBy ?user ; "
-                    + "        ?inContext ?ctx . "
+                    + "        ?inContext ?ctx ; "
+                    + "        ?countable ?true . "
                     + "?ctx ?basedOn ?voc . "
                     + "}", Integer.class)
                 .setParameter("type", typeUri)
@@ -489,6 +505,8 @@ public class PublicationContextDao extends BaseDao<PublicationContext> {
                 .setParameter("reviewedBy", reviewRelationUri)
                 .setParameter("user", userUri)
                 .setParameter("inContext", URI.create(TermVocabulary.s_p_v_kontextu))
+                .setParameter("countable", URI.create(TermVocabulary.s_p_je_pocitatelna_do_statistiky))
+                .setParameter("true", true)
                 .setParameter("basedOn", URI.create(TermVocabulary.s_p_vychazi_z_verze))
                 .setParameter("voc", vocabularyUri)
                 .getSingleResult();

--- a/src/main/java/com/github/checkit/dto/ChangeDto.java
+++ b/src/main/java/com/github/checkit/dto/ChangeDto.java
@@ -1,5 +1,6 @@
 package com.github.checkit.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.github.checkit.dto.auxiliary.ChangeState;
 import com.github.checkit.model.Change;
@@ -29,6 +30,8 @@ public class ChangeDto implements Comparable<ChangeDto> {
     private final ChangeState state;
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private final CommentDto rejectionComment;
+    @JsonIgnore
+    private final boolean countable;
 
     /**
      * Constructor.
@@ -50,6 +53,29 @@ public class ChangeDto implements Comparable<ChangeDto> {
         }
         this.state = resolveChangeState(change, user);
         this.rejectionComment = rejectionComment;
+        this.countable = change.getCountable();
+    }
+
+    /**
+     * Constructor for change before persisting.
+     */
+    public ChangeDto(Change change) {
+        this.id = change.getId();
+        this.uri = change.getUri();
+        this.type = change.getChangeType();
+        this.subjectType = change.getSubjectType();
+        this.label = null;
+        this.subject = change.getSubject();
+        this.predicate = change.getPredicate();
+        this.object = new ChangeObjectDto(change.getObject());
+        if (Objects.nonNull(change.getNewObject())) {
+            this.newObject = new ChangeObjectDto(change.getNewObject());
+        } else {
+            this.newObject = null;
+        }
+        this.state = null;
+        this.rejectionComment = null;
+        this.countable = true;
     }
 
     /**
@@ -67,6 +93,7 @@ public class ChangeDto implements Comparable<ChangeDto> {
         this.newObject = null;
         this.state = changeState;
         this.rejectionComment = null;
+        this.countable = false;
     }
 
     private String resolveLabel(Change change, String languageTag, String defaultLanguageTag) {

--- a/src/main/java/com/github/checkit/dto/ChangeDto.java
+++ b/src/main/java/com/github/checkit/dto/ChangeDto.java
@@ -73,7 +73,7 @@ public class ChangeDto implements Comparable<ChangeDto> {
         } else {
             this.newObject = null;
         }
-        this.state = null;
+        this.state = ChangeState.NOT_REVIEWED;
         this.rejectionComment = null;
         this.countable = true;
     }

--- a/src/main/java/com/github/checkit/dto/ReviewableVocabularyDto.java
+++ b/src/main/java/com/github/checkit/dto/ReviewableVocabularyDto.java
@@ -1,6 +1,5 @@
 package com.github.checkit.dto;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.github.checkit.model.Vocabulary;
 import java.net.URI;
 import java.util.List;
@@ -12,7 +11,6 @@ public class ReviewableVocabularyDto {
     private final URI uri;
     private final String label;
     private final boolean gestored;
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     private final VocabularyStatisticsDto statistics;
     private final List<UserDto> gestors;
 

--- a/src/main/java/com/github/checkit/dto/VocabularyStatisticsDto.java
+++ b/src/main/java/com/github/checkit/dto/VocabularyStatisticsDto.java
@@ -1,20 +1,24 @@
 package com.github.checkit.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Getter;
+import lombok.Setter;
 
 @Getter
 public class VocabularyStatisticsDto {
 
     private final int totalChanges;
-    private final int approvedChanges;
-    private final int rejectedChanges;
+    @Setter
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private Integer approvedChanges;
+    @Setter
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private Integer rejectedChanges;
 
     /**
      * Constructor.
      */
-    public VocabularyStatisticsDto(int totalChanges, int approvedChanges, int rejectedChanges) {
+    public VocabularyStatisticsDto(int totalChanges) {
         this.totalChanges = totalChanges;
-        this.approvedChanges = approvedChanges;
-        this.rejectedChanges = rejectedChanges;
     }
 }

--- a/src/main/java/com/github/checkit/model/Change.java
+++ b/src/main/java/com/github/checkit/model/Change.java
@@ -40,6 +40,11 @@ public class Change extends AbstractCommentableEntity {
     @OWLDataProperty(iri = RDFS.LABEL)
     private MultilingualString label;
 
+    @NotBlank
+    @ParticipationConstraints(nonEmpty = true)
+    @OWLDataProperty(iri = TermVocabulary.s_p_je_pocitatelna_do_statistiky)
+    private Boolean countable;
+
     @Enumerated
     @OWLDataProperty(iri = TermVocabulary.s_p_ma_popis_typu_subjektu)
     private ChangeSubjectType subjectType;

--- a/src/main/java/com/github/checkit/model/ChangeObject.java
+++ b/src/main/java/com/github/checkit/model/ChangeObject.java
@@ -14,7 +14,6 @@ import lombok.NoArgsConstructor;
 
 @Data
 @NoArgsConstructor
-@EqualsAndHashCode(callSuper = true)
 @OWLClass(iri = TermVocabulary.s_c_objekt_zmeny)
 public class ChangeObject extends AbstractEntity {
 
@@ -43,5 +42,23 @@ public class ChangeObject extends AbstractEntity {
 
     public String getLanguage() {
         return isBlankNode() ? null : this.valueWithLanguageTag.getLanguages().iterator().next();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ChangeObject that = (ChangeObject) o;
+        return Objects.equals(valueWithLanguageTag, that.valueWithLanguageTag) && Objects.equals(type,
+            that.type);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(valueWithLanguageTag, type);
     }
 }

--- a/src/main/java/com/github/checkit/service/ChangeService.java
+++ b/src/main/java/com/github/checkit/service/ChangeService.java
@@ -227,6 +227,10 @@ public class ChangeService extends BaseRepositoryService<Change> {
         }
     }
 
+    public URI generateEntityUri() {
+        return changeDao.generateEntityUri();
+    }
+
     private void checkNotInClosedPublicationContext(URI changeUri) {
         if (changeDao.isChangesPublicationContextClosed(changeUri)) {
             throw PublicationContextIsClosedException.create(changeUri);

--- a/src/main/java/com/github/checkit/service/PublicationContextService.java
+++ b/src/main/java/com/github/checkit/service/PublicationContextService.java
@@ -138,7 +138,7 @@ public class PublicationContextService extends BaseRepositoryService<Publication
     }
 
     /**
-     * Returns how many mages are available to show of closed publication contexts.
+     * Returns how many pages are available to show of closed publication contexts.
      */
     public int getPageCountOfClosedPublicationContexts() {
         return (int) Math.ceil((double) publicationContextDao.countAllClosed() / pageSize);

--- a/src/main/java/com/github/checkit/service/PublicationContextService.java
+++ b/src/main/java/com/github/checkit/service/PublicationContextService.java
@@ -329,7 +329,11 @@ public class PublicationContextService extends BaseRepositoryService<Publication
     }
 
     private void assignUris(Set<Change> newlyFormedOfChanges) {
-        newlyFormedOfChanges.forEach(change -> change.setUri(changeService.generateEntityUri()));
+        for (Change change : newlyFormedOfChanges) {
+            if (Objects.isNull(change.getUri())) {
+                change.setUri(changeService.generateEntityUri());
+            }
+        }
     }
 
     private void checkCanReview(PublicationContext pc, User user) {

--- a/src/main/java/com/github/checkit/util/TermVocabulary.java
+++ b/src/main/java/com/github/checkit/util/TermVocabulary.java
@@ -49,6 +49,8 @@ public final class TermVocabulary {
     public static final String s_p_ma_hodnotu = CHANGE_DESCRIPTION_NAMESPACE + "má-hodnotu";
     public static final String s_p_ma_typ_hodnoty = CHANGE_DESCRIPTION_NAMESPACE + "má-typ-hodnoty";
     public static final String s_p_ma_stitek = CHANGE_DESCRIPTION_NAMESPACE + "má-štítek";
+    public static final String s_p_je_pocitatelna_do_statistiky = CHANGE_DESCRIPTION_NAMESPACE
+        + "je-počitatelná-do-statistiky";
 
     /**
      * Other terms definition.


### PR DESCRIPTION
## Modified endpoints:

GET `/publication-contexts/{{Publication_ID}}` now returns statistics of total changes of each vocabulary.