### PR TITLE
Notifications

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ plugins {
 }
 
 group = 'com.github'
-version = "0.4.3"
+version = "0.5.0"
 
 compileJava {
     sourceCompatibility = '17'

--- a/src/main/java/com/github/checkit/config/properties/ApplicationConfigProperties.java
+++ b/src/main/java/com/github/checkit/config/properties/ApplicationConfigProperties.java
@@ -22,13 +22,23 @@ public class ApplicationConfigProperties {
     private CommentProperties comment;
     @Nonnull
     private PublicationContextProperties publicationContext;
-
+    @Nonnull
+    private NotificationProperties notification;
 
     @Getter
     @Setter
     @Configuration
     @ConfigurationProperties("publicationcontext")
     public static class PublicationContextProperties {
+        @Nonnull
+        private Integer pageSize;
+    }
+
+    @Getter
+    @Setter
+    @Configuration
+    @ConfigurationProperties("notification")
+    public static class NotificationProperties {
         @Nonnull
         private Integer pageSize;
     }

--- a/src/main/java/com/github/checkit/config/properties/RepositoryConfigProperties.java
+++ b/src/main/java/com/github/checkit/config/properties/RepositoryConfigProperties.java
@@ -36,6 +36,9 @@ public class RepositoryConfigProperties {
     @Nonnull
     private CommentProperties comment;
 
+    @Nonnull
+    private NotificationProperties notification;
+
     @Getter
     @Setter
     @Configuration
@@ -64,6 +67,16 @@ public class RepositoryConfigProperties {
     @Configuration
     @ConfigurationProperties("comment")
     public static class CommentProperties {
+
+        @Nonnull
+        private String context;
+    }
+
+    @Getter
+    @Setter
+    @Configuration
+    @ConfigurationProperties("notification")
+    public static class NotificationProperties {
 
         @Nonnull
         private String context;

--- a/src/main/java/com/github/checkit/controller/NotificationController.java
+++ b/src/main/java/com/github/checkit/controller/NotificationController.java
@@ -7,6 +7,7 @@ import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -37,7 +38,7 @@ public class NotificationController extends BaseController {
 
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @PostMapping("/seen")
-    public void markSeen(@RequestParam URI notificationUri) {
+    public void markSeen(@RequestBody URI notificationUri) {
         notificationService.markSeen(notificationUri);
     }
 }

--- a/src/main/java/com/github/checkit/controller/NotificationController.java
+++ b/src/main/java/com/github/checkit/controller/NotificationController.java
@@ -1,0 +1,38 @@
+package com.github.checkit.controller;
+
+import com.github.checkit.dto.NotificationDto;
+import com.github.checkit.service.NotificationService;
+import java.net.URI;
+import java.util.List;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(NotificationController.MAPPING)
+public class NotificationController extends BaseController {
+
+    public static final String MAPPING = "/notifications";
+
+    private final NotificationService notificationService;
+
+    public NotificationController(NotificationService notificationService) {
+        this.notificationService = notificationService;
+    }
+
+    @GetMapping
+    public List<NotificationDto> getAllForCurrent(@RequestParam(required = false, defaultValue = "0") int pageNumber,
+                                                  @RequestParam String languageTag) {
+        return notificationService.getAllForCurrent(pageNumber, languageTag);
+    }
+
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @PostMapping("/seen")
+    public void markSeen(@RequestParam URI notificationUri) {
+        notificationService.markSeen(notificationUri);
+    }
+}

--- a/src/main/java/com/github/checkit/controller/NotificationController.java
+++ b/src/main/java/com/github/checkit/controller/NotificationController.java
@@ -30,6 +30,11 @@ public class NotificationController extends BaseController {
         return notificationService.getAllForCurrent(pageNumber, languageTag);
     }
 
+    @GetMapping("/unread/count")
+    public int getUnreadCountForCurrent() {
+        return notificationService.getUnreadCountForCurrent();
+    }
+
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @PostMapping("/seen")
     public void markSeen(@RequestParam URI notificationUri) {

--- a/src/main/java/com/github/checkit/dao/NotificationDao.java
+++ b/src/main/java/com/github/checkit/dao/NotificationDao.java
@@ -90,4 +90,30 @@ public class NotificationDao extends BaseDao<Notification> {
             throw new PersistenceException(e);
         }
     }
+
+    /**
+     * Gets number of unread notifications for current user.
+     *
+     * @return number of notifications
+     */
+    public int getUnreadCountForUser(URI userUri) {
+        Objects.requireNonNull(userUri);
+        try {
+            return em.createNativeQuery("SELECT (COUNT(?n) as ?count) WHERE { "
+                    + "?n a ?type ;"
+                    + "   ?addressedTo ?user . "
+                    + "FILTER NOT EXISTS { "
+                    + "     ?n ?readAt ?time . "
+                    + "     } "
+                    + "}", Integer.class)
+                .setParameter("type", typeUri)
+                .setParameter("addressedTo", URI.create(TermVocabulary.s_p_addressed_to))
+                .setParameter("user", userUri)
+                .setParameter("readAt", URI.create(TermVocabulary.s_p_read_at))
+                .setDescriptor(descriptorFactory.notificationDescriptor())
+                .getSingleResult();
+        } catch (RuntimeException e) {
+            throw new PersistenceException(e);
+        }
+    }
 }

--- a/src/main/java/com/github/checkit/dao/NotificationDao.java
+++ b/src/main/java/com/github/checkit/dao/NotificationDao.java
@@ -1,0 +1,93 @@
+package com.github.checkit.dao;
+
+import com.github.checkit.exception.PersistenceException;
+import com.github.checkit.model.Notification;
+import com.github.checkit.persistence.DescriptorFactory;
+import com.github.checkit.util.TermVocabulary;
+import cz.cvut.kbss.jopa.model.EntityManager;
+import java.net.URI;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class NotificationDao extends BaseDao<Notification> {
+
+    private final DescriptorFactory descriptorFactory;
+
+    protected NotificationDao(EntityManager em, DescriptorFactory descriptorFactory) {
+        super(Notification.class, em);
+        this.descriptorFactory = descriptorFactory;
+    }
+
+    @Override
+    public List<Notification> findAll() {
+        try {
+            return em.createNativeQuery("SELECT ?n WHERE { ?n a ?type . }", type)
+                .setParameter("type", typeUri)
+                .setDescriptor(descriptorFactory.notificationDescriptor())
+                .getResultList();
+        } catch (RuntimeException e) {
+            throw new PersistenceException(e);
+        }
+    }
+
+    /**
+     * Finds all notifications for specified user.
+     *
+     * @param userUri    URI identifier of user
+     * @param pageNumber page number
+     * @param pageSize   page size
+     */
+    public List<Notification> getAllForUser(URI userUri, int pageNumber, int pageSize) {
+        Objects.requireNonNull(userUri);
+        try {
+            return em.createNativeQuery("SELECT ?n WHERE { "
+                    + "?n a ?type ;"
+                    + "   ?addressedTo ?user ; "
+                    + "   ?created ?time . "
+                    + "} ORDER BY DESC(?time)", type)
+                .setParameter("type", typeUri)
+                .setParameter("addressedTo", URI.create(TermVocabulary.s_p_addressed_to))
+                .setParameter("user", userUri)
+                .setParameter("created", URI.create(TermVocabulary.s_p_ma_datum_a_cas_vytvoreni))
+                .setFirstResult(pageNumber * pageSize)
+                .setMaxResults(pageSize)
+                .setDescriptor(descriptorFactory.notificationDescriptor())
+                .getResultList();
+        } catch (RuntimeException e) {
+            throw new PersistenceException(e);
+        }
+    }
+
+    @Override
+    public Optional<Notification> find(URI id) {
+        Objects.requireNonNull(id);
+        try {
+            return Optional.ofNullable(em.find(type, id, descriptorFactory.notificationDescriptor()));
+        } catch (RuntimeException e) {
+            throw new PersistenceException(e);
+        }
+    }
+
+    @Override
+    public void persist(Notification entity) {
+        Objects.requireNonNull(entity);
+        try {
+            em.persist(entity, descriptorFactory.notificationDescriptor());
+        } catch (RuntimeException e) {
+            throw new PersistenceException(e);
+        }
+    }
+
+    @Override
+    public Notification update(Notification entity) {
+        Objects.requireNonNull(entity);
+        try {
+            return em.merge(entity, descriptorFactory.notificationDescriptor());
+        } catch (RuntimeException e) {
+            throw new PersistenceException(e);
+        }
+    }
+}

--- a/src/main/java/com/github/checkit/dto/ChangeDto.java
+++ b/src/main/java/com/github/checkit/dto/ChangeDto.java
@@ -7,6 +7,7 @@ import com.github.checkit.model.Change;
 import com.github.checkit.model.ChangeType;
 import com.github.checkit.model.User;
 import com.github.checkit.model.auxilary.ChangeSubjectType;
+import com.github.checkit.util.Utils;
 import java.net.URI;
 import java.util.Comparator;
 import java.util.Objects;
@@ -42,7 +43,7 @@ public class ChangeDto implements Comparable<ChangeDto> {
         this.uri = change.getUri();
         this.type = change.getChangeType();
         this.subjectType = change.getSubjectType();
-        this.label = resolveLabel(change, languageTag, defaultLanguageTag);
+        this.label = Utils.resolveMultilingual(change.getLabel(), languageTag, defaultLanguageTag);
         this.subject = change.getSubject();
         this.predicate = change.getPredicate();
         this.object = new ChangeObjectDto(change.getObject());
@@ -94,16 +95,6 @@ public class ChangeDto implements Comparable<ChangeDto> {
         this.state = changeState;
         this.rejectionComment = null;
         this.countable = false;
-    }
-
-    private String resolveLabel(Change change, String languageTag, String defaultLanguageTag) {
-        if (change.getLabel().contains(languageTag)) {
-            return change.getLabel().get(languageTag);
-        }
-        if (change.getLabel().contains(defaultLanguageTag)) {
-            return change.getLabel().get(defaultLanguageTag);
-        }
-        return change.getLabel().get();
     }
 
     private ChangeState resolveChangeState(Change change, User user) {

--- a/src/main/java/com/github/checkit/dto/NotificationDto.java
+++ b/src/main/java/com/github/checkit/dto/NotificationDto.java
@@ -1,0 +1,32 @@
+package com.github.checkit.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.github.checkit.model.Notification;
+import com.github.checkit.util.Utils;
+import java.net.URI;
+import java.time.Instant;
+import lombok.Getter;
+
+@Getter
+public class NotificationDto {
+
+    private final URI uri;
+    private final String title;
+    private final String content;
+    private final String about;
+    private final Instant created;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private final Instant readAt;
+
+    /**
+     * Constructor.
+     */
+    public NotificationDto(Notification notification, String languageTag) {
+        this.uri = notification.getUri();
+        this.title = Utils.resolveMultilingual(notification.getTitle(), languageTag);
+        this.content = Utils.resolveMultilingual(notification.getContent(), languageTag);
+        this.about = notification.getAbout();
+        this.created = notification.getCreated();
+        this.readAt = notification.getReadAt();
+    }
+}

--- a/src/main/java/com/github/checkit/exception/ForbiddenException.java
+++ b/src/main/java/com/github/checkit/exception/ForbiddenException.java
@@ -19,4 +19,8 @@ public class ForbiddenException extends BaseException {
     public static ForbiddenException createForbiddenToReviewChange(URI userUri, URI changeUri) {
         return new ForbiddenException("User \"%s\" can't review change \"%s\".", userUri, changeUri);
     }
+
+    public static ForbiddenException createForbiddenToMarkNotification() {
+        return new ForbiddenException("Can't mark notifications of other users as read.");
+    }
 }

--- a/src/main/java/com/github/checkit/model/Change.java
+++ b/src/main/java/com/github/checkit/model/Change.java
@@ -18,7 +18,9 @@ import cz.cvut.kbss.jopa.vocabulary.RDF;
 import cz.cvut.kbss.jopa.vocabulary.RDFS;
 import jakarta.validation.constraints.NotBlank;
 import java.net.URI;
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import lombok.Data;
@@ -169,5 +171,17 @@ public class Change extends AbstractCommentableEntity {
 
     public boolean notApproved() {
         return getApprovedBy().isEmpty();
+    }
+
+    /**
+     * Gets users who reviewed this change.
+     *
+     * @return list of users
+     */
+    public List<User> getReviewBy() {
+        List<User> reviewedBy = new ArrayList<>();
+        reviewedBy.addAll(getApprovedBy());
+        reviewedBy.addAll(getRejectedBy());
+        return reviewedBy;
     }
 }

--- a/src/main/java/com/github/checkit/model/Notification.java
+++ b/src/main/java/com/github/checkit/model/Notification.java
@@ -1,0 +1,54 @@
+package com.github.checkit.model;
+
+import com.github.checkit.model.auxilary.AbstractEntity;
+import com.github.checkit.util.TermVocabulary;
+import cz.cvut.kbss.jopa.model.annotations.OWLClass;
+import cz.cvut.kbss.jopa.model.annotations.OWLDataProperty;
+import cz.cvut.kbss.jopa.model.annotations.ParticipationConstraints;
+import cz.cvut.kbss.jopa.model.annotations.PrePersist;
+import cz.cvut.kbss.jopa.vocabulary.DC;
+import jakarta.validation.constraints.NotBlank;
+import java.net.URL;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+@OWLClass(iri = TermVocabulary.s_c_notifikace)
+public class Notification extends AbstractEntity {
+
+    @NotBlank
+    @ParticipationConstraints(nonEmpty = true)
+    @OWLDataProperty(iri = DC.Terms.TITLE)
+    private String title;
+
+    @NotBlank
+    @ParticipationConstraints(nonEmpty = true)
+    @OWLDataProperty(iri = TermVocabulary.s_p_content)
+    private String content;
+
+    @NotBlank
+    @ParticipationConstraints(nonEmpty = true)
+    @OWLDataProperty(iri = TermVocabulary.s_p_about)
+    private URL about;
+
+    @NotBlank
+    @ParticipationConstraints(nonEmpty = true)
+    @OWLDataProperty(iri = TermVocabulary.s_p_ma_datum_a_cas_vytvoreni)
+    private Instant created;
+
+    @NotBlank
+    @ParticipationConstraints(nonEmpty = true)
+    @OWLDataProperty(iri = TermVocabulary.s_p_addressed_to)
+    private User addressedTo;
+
+    @OWLDataProperty(iri = TermVocabulary.s_p_read_at)
+    private Instant readAt;
+
+    @PrePersist
+    public void prePersist() {
+        this.created = Instant.now().truncatedTo(ChronoUnit.MILLIS);
+    }
+}

--- a/src/main/java/com/github/checkit/model/Notification.java
+++ b/src/main/java/com/github/checkit/model/Notification.java
@@ -2,19 +2,22 @@ package com.github.checkit.model;
 
 import com.github.checkit.model.auxilary.AbstractEntity;
 import com.github.checkit.util.TermVocabulary;
+import cz.cvut.kbss.jopa.model.MultilingualString;
 import cz.cvut.kbss.jopa.model.annotations.OWLClass;
 import cz.cvut.kbss.jopa.model.annotations.OWLDataProperty;
+import cz.cvut.kbss.jopa.model.annotations.OWLObjectProperty;
 import cz.cvut.kbss.jopa.model.annotations.ParticipationConstraints;
 import cz.cvut.kbss.jopa.model.annotations.PrePersist;
 import cz.cvut.kbss.jopa.vocabulary.DC;
 import jakarta.validation.constraints.NotBlank;
-import java.net.URL;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
 
 @Data
+@NoArgsConstructor
 @EqualsAndHashCode(callSuper = true)
 @OWLClass(iri = TermVocabulary.s_c_notifikace)
 public class Notification extends AbstractEntity {
@@ -22,17 +25,17 @@ public class Notification extends AbstractEntity {
     @NotBlank
     @ParticipationConstraints(nonEmpty = true)
     @OWLDataProperty(iri = DC.Terms.TITLE)
-    private String title;
+    private MultilingualString title;
 
     @NotBlank
     @ParticipationConstraints(nonEmpty = true)
     @OWLDataProperty(iri = TermVocabulary.s_p_content)
-    private String content;
+    private MultilingualString content;
 
     @NotBlank
     @ParticipationConstraints(nonEmpty = true)
     @OWLDataProperty(iri = TermVocabulary.s_p_about)
-    private URL about;
+    private String about;
 
     @NotBlank
     @ParticipationConstraints(nonEmpty = true)
@@ -41,7 +44,7 @@ public class Notification extends AbstractEntity {
 
     @NotBlank
     @ParticipationConstraints(nonEmpty = true)
-    @OWLDataProperty(iri = TermVocabulary.s_p_addressed_to)
+    @OWLObjectProperty(iri = TermVocabulary.s_p_addressed_to)
     private User addressedTo;
 
     @OWLDataProperty(iri = TermVocabulary.s_p_read_at)
@@ -50,5 +53,22 @@ public class Notification extends AbstractEntity {
     @PrePersist
     public void prePersist() {
         this.created = Instant.now().truncatedTo(ChronoUnit.MILLIS);
+    }
+
+    /**
+     * Creates a copy using specified notification as template (only deep coping title, content and about).
+     *
+     * @param template notification
+     */
+    public static Notification createFromTemplate(Notification template) {
+        Notification notification = new Notification();
+        notification.setTitle(new MultilingualString(template.getTitle().getValue()));
+        notification.setContent(new MultilingualString(template.getContent().getValue()));
+        notification.setAbout(template.getAbout());
+        return notification;
+    }
+
+    public void markRead() {
+        setReadAt(Instant.now().truncatedTo(ChronoUnit.MILLIS));
     }
 }

--- a/src/main/java/com/github/checkit/model/ProjectContext.java
+++ b/src/main/java/com/github/checkit/model/ProjectContext.java
@@ -6,7 +6,9 @@ import cz.cvut.kbss.jopa.model.annotations.FetchType;
 import cz.cvut.kbss.jopa.model.annotations.OWLClass;
 import cz.cvut.kbss.jopa.model.annotations.OWLDataProperty;
 import cz.cvut.kbss.jopa.model.annotations.OWLObjectProperty;
+import cz.cvut.kbss.jopa.model.annotations.ParticipationConstraints;
 import cz.cvut.kbss.jopa.vocabulary.DC;
+import jakarta.validation.constraints.NotBlank;
 import java.util.Set;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -16,8 +18,15 @@ import lombok.EqualsAndHashCode;
 @OWLClass(iri = TermVocabulary.s_c_metadatovy_kontext)
 public class ProjectContext extends AbstractEntity {
 
+    @NotBlank
+    @ParticipationConstraints(nonEmpty = true)
     @OWLDataProperty(iri = DC.Terms.TITLE)
     private String label;
+
+    @NotBlank
+    @ParticipationConstraints(nonEmpty = true)
+    @OWLObjectProperty(iri = TermVocabulary.s_p_ma_autora)
+    private User author;
 
     @OWLObjectProperty(iri = TermVocabulary.s_p_odkazuje_na_kontext, fetch = FetchType.EAGER)
     private Set<VocabularyContext> vocabularyContexts;

--- a/src/main/java/com/github/checkit/persistence/DescriptorFactory.java
+++ b/src/main/java/com/github/checkit/persistence/DescriptorFactory.java
@@ -184,7 +184,7 @@ public class DescriptorFactory {
      * <p>The descriptor specifies that the instance will correspond to the set IRI.
      * It also initializes other required attribute descriptors.
      *
-     * @return Change descriptor
+     * @return Comment descriptor
      */
     public Descriptor commentDescriptor() {
         URI contextUri = URI.create(repositoryConfigProperties.getComment().getContext());
@@ -192,6 +192,22 @@ public class DescriptorFactory {
         descriptor.addAttributeDescriptor(fieldSpec(Comment.class, "topic"),
             new EntityDescriptor((URI) null));
         descriptor.addAttributeDescriptor(fieldSpec(Comment.class, "author"),
+            new EntityDescriptor((URI) null));
+        return descriptor;
+    }
+
+    /**
+     * Creates a JOPA descriptor for a notification entity.
+     *
+     * <p>The descriptor specifies that the instance will correspond to the set IRI.
+     * It also initializes other required attribute descriptors.
+     *
+     * @return Notification descriptor
+     */
+    public Descriptor notificationDescriptor() {
+        URI contextUri = URI.create(repositoryConfigProperties.getNotification().getContext());
+        EntityDescriptor descriptor = entityDescriptor(contextUri);
+        descriptor.addAttributeDescriptor(fieldSpec(Comment.class, "addressedTo"),
             new EntityDescriptor((URI) null));
         return descriptor;
     }

--- a/src/main/java/com/github/checkit/persistence/DescriptorFactory.java
+++ b/src/main/java/com/github/checkit/persistence/DescriptorFactory.java
@@ -4,6 +4,7 @@ import com.github.checkit.config.properties.RepositoryConfigProperties;
 import com.github.checkit.model.Change;
 import com.github.checkit.model.Comment;
 import com.github.checkit.model.GestoringRequest;
+import com.github.checkit.model.Notification;
 import com.github.checkit.model.ProjectContext;
 import com.github.checkit.model.PublicationContext;
 import com.github.checkit.model.Vocabulary;
@@ -175,6 +176,8 @@ public class DescriptorFactory {
         EntityDescriptor descriptor = entityDescriptor(projectContextUri);
         descriptor.addAttributeDescriptor(fieldSpec(ProjectContext.class, "vocabularyContexts"),
             new EntityDescriptor((URI) null));
+        descriptor.addAttributeDescriptor(fieldSpec(ProjectContext.class, "author"),
+            new EntityDescriptor((URI) null));
         return descriptor;
     }
 
@@ -207,7 +210,7 @@ public class DescriptorFactory {
     public Descriptor notificationDescriptor() {
         URI contextUri = URI.create(repositoryConfigProperties.getNotification().getContext());
         EntityDescriptor descriptor = entityDescriptor(contextUri);
-        descriptor.addAttributeDescriptor(fieldSpec(Comment.class, "addressedTo"),
+        descriptor.addAttributeDescriptor(fieldSpec(Notification.class, "addressedTo"),
             new EntityDescriptor((URI) null));
         return descriptor;
     }

--- a/src/main/java/com/github/checkit/service/NotificationService.java
+++ b/src/main/java/com/github/checkit/service/NotificationService.java
@@ -1,0 +1,131 @@
+package com.github.checkit.service;
+
+import com.github.checkit.config.properties.ApplicationConfigProperties;
+import com.github.checkit.dao.BaseDao;
+import com.github.checkit.dao.NotificationDao;
+import com.github.checkit.dto.NotificationDto;
+import com.github.checkit.exception.ForbiddenException;
+import com.github.checkit.model.Notification;
+import com.github.checkit.model.PublicationContext;
+import com.github.checkit.model.User;
+import com.github.checkit.model.Vocabulary;
+import com.github.checkit.util.KeycloakApiUtil;
+import com.github.checkit.util.NotificationTemplateUtil;
+import java.net.URI;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class NotificationService extends BaseRepositoryService<Notification> {
+
+    private final NotificationDao notificationDao;
+    private final UserService userService;
+    private final VocabularyService vocabularyService;
+    private final CommentService commentService;
+    private final KeycloakApiUtil keycloakApiUtil;
+    private final int pageSize;
+
+    /**
+     * Constructor.
+     */
+    public NotificationService(NotificationDao notificationDao, UserService userService,
+                               VocabularyService vocabularyService, CommentService commentService,
+                               KeycloakApiUtil keycloakApiUtil,
+                               ApplicationConfigProperties applicationConfigProperties) {
+        this.notificationDao = notificationDao;
+        this.userService = userService;
+        this.vocabularyService = vocabularyService;
+        this.commentService = commentService;
+        this.keycloakApiUtil = keycloakApiUtil;
+        this.pageSize = applicationConfigProperties.getNotification().getPageSize();
+    }
+
+    @Override
+    protected BaseDao<Notification> getPrimaryDao() {
+        return notificationDao;
+    }
+
+    /**
+     * Gets notifications for current user.
+     *
+     * @param pageNumber  page number
+     * @param languageTag preferred language tag
+     * @return list of notifications
+     */
+    @Transactional(readOnly = true)
+    public List<NotificationDto> getAllForCurrent(int pageNumber, String languageTag) {
+        User current = userService.getCurrent();
+        List<Notification> notifications = notificationDao.getAllForUser(current.getUri(), pageNumber, pageSize);
+        return notifications.stream().map(notification -> new NotificationDto(notification, languageTag)).toList();
+    }
+
+    /**
+     * Marks specified notification as read.
+     *
+     * @param notificationUri URI identifier of notification
+     */
+    @Transactional
+    public void markSeen(URI notificationUri) {
+        Notification notification = findRequired(notificationUri);
+        if (!notification.getAddressedTo().equals(userService.getCurrent())) {
+            throw ForbiddenException.createForbiddenToMarkNotification();
+        }
+        notification.markRead();
+        update(notification);
+    }
+
+    /**
+     * Creates notifications for gestors about new publication context.
+     *
+     * @param publicationContext publication context
+     */
+    @Transactional
+    public void createdPublication(PublicationContext publicationContext) {
+        Set<User> gestorUsers = new HashSet<>();
+        Set<URI> vocabularyURIs = new HashSet<>();
+        publicationContext.getChanges().forEach(change -> vocabularyURIs.add(change.getContext().getBasedOnVersion()));
+        boolean noNewVocabulary = true;
+        for (URI vocabularyURI : vocabularyURIs) {
+            Optional<Vocabulary> optVocabulary = vocabularyService.find(vocabularyURI);
+            if (optVocabulary.isPresent()) {
+                gestorUsers.addAll(optVocabulary.get().getGestors());
+            } else {
+                noNewVocabulary = false;
+            }
+        }
+        Notification template = NotificationTemplateUtil.getForCreatedPublicationContext(publicationContext);
+        for (User gestorUser : gestorUsers) {
+            Notification notification = Notification.createFromTemplate(template);
+            notification.setAddressedTo(gestorUser);
+            persist(notification);
+        }
+        if (noNewVocabulary) {
+            return;
+        }
+        template = NotificationTemplateUtil.getForCreatedPublicationContextForAdmin(publicationContext);
+        for (String adminId : keycloakApiUtil.getAdminIds()) {
+            Notification notification = Notification.createFromTemplate(template);
+            notification.setAddressedTo(userService.findRequiredByUserId(adminId));
+            persist(notification);
+        }
+    }
+
+    /**
+     * Creates notifications for gestors about new version of existing publication context.
+     *
+     * @param publicationContext publication context
+     */
+    @Transactional
+    public void updatedPublication(PublicationContext publicationContext, Set<User> reviewers) {
+        Notification template = NotificationTemplateUtil.getForUpdatedPublicationContext(publicationContext);
+        for (User reviewer : reviewers) {
+            Notification notification = Notification.createFromTemplate(template);
+            notification.setAddressedTo(reviewer);
+            persist(notification);
+        }
+    }
+}

--- a/src/main/java/com/github/checkit/service/NotificationService.java
+++ b/src/main/java/com/github/checkit/service/NotificationService.java
@@ -63,6 +63,11 @@ public class NotificationService extends BaseRepositoryService<Notification> {
         return notifications.stream().map(notification -> new NotificationDto(notification, languageTag)).toList();
     }
 
+    public int getUnreadCountForCurrent() {
+        User current = userService.getCurrent();
+        return notificationDao.getUnreadCountForUser(current.getUri());
+    }
+
     /**
      * Marks specified notification as read.
      *

--- a/src/main/java/com/github/checkit/util/FrontendPaths.java
+++ b/src/main/java/com/github/checkit/util/FrontendPaths.java
@@ -1,0 +1,12 @@
+package com.github.checkit.util;
+
+/**
+ * This class contains some URL paths of Frontend CheckIt used in notifications.
+ */
+public final class FrontendPaths {
+
+    public static String PUBLICATION_SEPARATOR = "publications";
+
+    public static String PUBLICATIONS_PATH = "/" + PUBLICATION_SEPARATOR;
+    public static String PUBLICATION_DETAIL_PATH = PUBLICATIONS_PATH + "/";
+}

--- a/src/main/java/com/github/checkit/util/KeycloakApiUtil.java
+++ b/src/main/java/com/github/checkit/util/KeycloakApiUtil.java
@@ -79,6 +79,11 @@ public class KeycloakApiUtil {
         return api.clients().get(clientUUID).roles().get(adminRole.getName()).getUserMembers().size();
     }
 
+    public List<String> getAdminIds() {
+        return api.clients().get(clientUUID).roles().get(adminRole.getName()).getUserMembers()
+            .stream().map(UserRepresentation::getId).toList();
+    }
+
     private UserResource fetchUser(String userId) {
         try {
             UserResource user = api.users().get(userId);

--- a/src/main/java/com/github/checkit/util/NotificationTemplateUtil.java
+++ b/src/main/java/com/github/checkit/util/NotificationTemplateUtil.java
@@ -1,0 +1,66 @@
+package com.github.checkit.util;
+
+import com.github.checkit.model.Notification;
+import com.github.checkit.model.PublicationContext;
+import cz.cvut.kbss.jopa.model.MultilingualString;
+
+public final class NotificationTemplateUtil {
+
+    /**
+     * Creates template for created publication context.
+     *
+     * @param pc publication context
+     * @return Notification template
+     */
+    public static Notification getForCreatedPublicationContext(PublicationContext pc) {
+        Notification notification = new Notification();
+        notification.setTitle(
+            new MultilingualString().set("en", "New publication context").set("cs", "Nový publikační kontext"));
+        notification.setContent(new MultilingualString().set("en",
+            String.format("Publication context \"%s\" with vocabulary you gestor was created.",
+                pc.getFromProject().getLabel())).set("cs",
+            String.format("Byl vytvořen publikační kontext \"%s\" obsahující vámi gestorovaný slovník.",
+                pc.getFromProject().getLabel())));
+        notification.setAbout(FrontendPaths.PUBLICATION_DETAIL_PATH + pc.getId());
+        return notification;
+    }
+
+    /**
+     * Creates template for created publication context with message for admin about newly created vocabulary.
+     *
+     * @param pc publication context
+     * @return Notification template
+     */
+    public static Notification getForCreatedPublicationContextForAdmin(PublicationContext pc) {
+        Notification notification = new Notification();
+        notification.setTitle(
+            new MultilingualString().set("en", "New vocabulary").set("cs", "Nový slovník"));
+        notification.setContent(new MultilingualString().set("en",
+            String.format("Publication context \"%s\" with newly created vocabulary was submitted.",
+                pc.getFromProject().getLabel())).set("cs",
+            String.format("Byl vytvořen publikační kontext \"%s\" s novým slovníkem.",
+                pc.getFromProject().getLabel())));
+        notification.setAbout(FrontendPaths.PUBLICATION_DETAIL_PATH + pc.getId());
+        return notification;
+    }
+
+    /**
+     * Creates template for updated publication context.
+     *
+     * @param pc publication context
+     * @return Notification template
+     */
+    public static Notification getForUpdatedPublicationContext(PublicationContext pc) {
+        Notification notification = new Notification();
+        notification.setTitle(
+            new MultilingualString().set("en", "Update of publication context").set("cs", "Aktualizace publikačního "
+                + "kontextu"));
+        notification.setContent(new MultilingualString().set("en",
+            String.format("Publication context \"%s\" with your review was updated.",
+                pc.getFromProject().getLabel())).set("cs",
+            String.format("Byl aktualizován publikační kontext \"%s\", který jste revidovali.",
+                pc.getFromProject().getLabel())));
+        notification.setAbout(FrontendPaths.PUBLICATION_DETAIL_PATH + pc.getId());
+        return notification;
+    }
+}

--- a/src/main/java/com/github/checkit/util/TermVocabulary.java
+++ b/src/main/java/com/github/checkit/util/TermVocabulary.java
@@ -32,6 +32,7 @@ public final class TermVocabulary {
     public static final String s_c_vraceno_zpet = CHANGE_DESCRIPTION_NAMESPACE + "vráceno-zpět";
     public static final String s_c_objekt_zmeny = CHANGE_DESCRIPTION_NAMESPACE + "objekt-změny";
     public static final String s_c_komentovatelna_entita = CHANGE_DESCRIPTION_NAMESPACE + "komentovatelná-entita";
+    public static final String s_c_notifikace = CHANGE_DESCRIPTION_NAMESPACE + "notifikace";
     public static final String s_p_ma_gestora = CHANGE_DESCRIPTION_NAMESPACE + "má-gestora";
     public static final String s_p_je_gestorem = CHANGE_DESCRIPTION_NAMESPACE + "je-gestorem";
     public static final String s_p_ma_zadatele = CHANGE_DESCRIPTION_NAMESPACE + "má-žadatele";
@@ -61,6 +62,7 @@ public final class TermVocabulary {
     public static final String s_c_slovnikovy_kontext = WORKSPACE_NAMESPACE + "slovníkový-kontext";
     public static final String s_c_prilohovy_kontext = WORKSPACE_NAMESPACE + "přílohový-kontext";
     public static final String s_c_slovnik = DATA_DESCRIPTION_NAMESPACE + "slovník";
+    public static final String s_c_Comment = SIOCT_NAMESPACE + "Comment";
     public static final String s_p_ma_krestni_jmeno = DATA_DESCRIPTION_NAMESPACE + "má-křestní-jméno";
     public static final String s_p_ma_prijmeni = DATA_DESCRIPTION_NAMESPACE + "má-příjmení";
     public static final String s_p_vychazi_z_verze = WORKSPACE_NAMESPACE + "vychází-z-verze";
@@ -74,5 +76,7 @@ public final class TermVocabulary {
     public static final String s_p_has_creator = SIOC_NAMESPACE + "has_creator";
     public static final String s_p_topic = SIOC_NAMESPACE + "topic";
     public static final String s_p_content = SIOC_NAMESPACE + "content";
-    public static final String s_c_Comment = SIOCT_NAMESPACE + "Comment";
+    public static final String s_p_read_at = SIOC_NAMESPACE + "read_at";
+    public static final String s_p_addressed_to = SIOC_NAMESPACE + "addressed_to";
+    public static final String s_p_about = SIOC_NAMESPACE + "about";
 }

--- a/src/main/java/com/github/checkit/util/TermVocabulary.java
+++ b/src/main/java/com/github/checkit/util/TermVocabulary.java
@@ -72,6 +72,7 @@ public final class TermVocabulary {
     public static final String s_p_ma_datum_a_cas_vytvoreni = DATA_DESCRIPTION_NAMESPACE + "má-datum-a-čas-vytvoření";
     public static final String s_p_ma_datum_a_cas_posledni_modifikace = DATA_DESCRIPTION_NAMESPACE
         + "má-datum-a-čas-poslední-modifikace";
+    public static final String s_p_ma_autora = DATA_DESCRIPTION_NAMESPACE + "má-autora";
     public static final String s_p_ma_vztazeny_prvek_1 = PRIMARY_VOCABULARY_NAMESPACE + "má-vztažený-prvek-1";
     public static final String s_p_has_creator = SIOC_NAMESPACE + "has_creator";
     public static final String s_p_topic = SIOC_NAMESPACE + "topic";

--- a/src/main/java/com/github/checkit/util/Utils.java
+++ b/src/main/java/com/github/checkit/util/Utils.java
@@ -1,0 +1,38 @@
+package com.github.checkit.util;
+
+import cz.cvut.kbss.jopa.model.MultilingualString;
+
+public final class Utils {
+
+    /**
+     * Gets string of specified language from multilingual string. If it does not exist returns any available string.
+     *
+     * @param multilingualString multilingual string
+     * @param languageTag        preferred language tag
+     * @return string
+     */
+    public static String resolveMultilingual(MultilingualString multilingualString, String languageTag) {
+        String res = multilingualString.get(languageTag);
+        return res != null ? res : multilingualString.get();
+    }
+
+    /**
+     * Gets string of specified language from multilingual string. If it does not exist returns string with default
+     * language tag or any available string.
+     *
+     * @param multilingualString multilingual string
+     * @param languageTag        preferred language tag
+     * @param defaultLanguageTag default language tag
+     * @return string
+     */
+    public static String resolveMultilingual(MultilingualString multilingualString, String languageTag,
+                                             String defaultLanguageTag) {
+        if (multilingualString.contains(languageTag)) {
+            return multilingualString.get(languageTag);
+        }
+        if (multilingualString.contains(defaultLanguageTag)) {
+            return multilingualString.get(defaultLanguageTag);
+        }
+        return multilingualString.get();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -38,4 +38,6 @@ repository:
     context: https://slovník.gov.cz/datový/popis-zmen/pozadavky-na-gestorovani
   comment:
     context: https://slovník.gov.cz/datový/popis-zmen/komentare
+  notification:
+    context: https://slovník.gov.cz/datový/popis-zmen/notifikace
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,6 +2,8 @@ application:
   version: ${version}
   publicationContext:
     pageSize: 15
+  notification:
+    pageSize: 15
   comment:
     rejectionMinimalContentLength: 10
 

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -37,5 +37,7 @@ repository:
     context: https://slovník.gov.cz/datový/popis-zmen/pozadavky-na-gestorovani
   comment:
     context: https://slovník.gov.cz/datový/popis-zmen/komentare
+  notification:
+    context: https://slovník.gov.cz/datový/popis-zmen/notifikace
 
 

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -2,8 +2,11 @@ application:
   version: ${version}
   publicationContext:
     pageSize: 15
+  notification:
+    pageSize: 15
   comment:
     rejectionMinimalContentLength: 10
+
 
 logging:
   level:


### PR DESCRIPTION
## New endpoints

**Fetch notifications for current user (sends in pages with default size 15)**
GET `/notifications` 
Requires param `languageTag` (two char code, now supports "cs" and "en")
Optional param `pageNumber` (default 0) specifies the page number

Response example: 
```json
[
    {
        "uri": "https://slovník.gov.cz/datový/popis-zmen/pojem/notifikace/instance-1987809090",
        "title": "New vocabulary",
        "content": "Publication context \"Notifikace\" with newly created vocabulary was submitted.",
        "about": "/publications/instance1580793267",
        "created": "2023-04-28T08:56:35.922Z",
        "readAt": "2023-04-28T09:20:56.398Z"
    },
    {
        "uri": "https://slovník.gov.cz/datový/popis-zmen/pojem/notifikace/instance1218269733",
        "title": "New publication context",
        "content": "Publication context \"Notifikace\" with vocabulary you gestor was created.",
        "about": "/publications/instance1580793267",
        "created": "2023-04-28T08:56:35.245Z"
    }
]
```

**Fetch number of unread notifications for current user**
GET `/notifications/unread/count` 

Response is an integer

**Mark specified notification as read**
POST `/notifications/seen` 
Request body is URI of notification, example:
`"https://slovník.gov.cz/datový/popis-zmen/pojem/notifikace/instance-1987809090"`
Response 204 NO CONTENT