### PR TITLE
Publication context detail sends users who approved vocabulary

### DIFF
--- a/src/main/java/com/github/checkit/dao/ChangeDao.java
+++ b/src/main/java/com/github/checkit/dao/ChangeDao.java
@@ -33,6 +33,37 @@ public class ChangeDao extends BaseDao<Change> {
         }
     }
 
+    /**
+     * Finds any change in specified context of specified publication context.
+     *
+     * @param publicationContextUri URI identifier of publication context
+     * @param contextUri            URI identifier of context
+     * @return change if context is present publication context
+     */
+    public Optional<Change> findAnyInContextInPublicationContext(URI publicationContextUri, URI contextUri) {
+        Objects.requireNonNull(publicationContextUri);
+        Objects.requireNonNull(contextUri);
+        try {
+            Optional<URI> anyChange = em.createNativeQuery("SELECT ?change WHERE { "
+                    + "?change a ?type ; "
+                    + "        ?inContext ?ctx . "
+                    + "?pc ?hasChange ?change . "
+                    + "}", URI.class)
+                .setParameter("type", typeUri)
+                .setParameter("inContext", URI.create(TermVocabulary.s_p_v_kontextu))
+                .setParameter("ctx", contextUri)
+                .setParameter("pc", publicationContextUri)
+                .setParameter("hasChange", URI.create(TermVocabulary.s_p_ma_zmenu))
+                .getResultStream().findFirst();
+            if (anyChange.isEmpty()) {
+                return Optional.empty();
+            }
+            return find(anyChange.get());
+        } catch (RuntimeException e) {
+            throw new PersistenceException(e);
+        }
+    }
+
     @Override
     public Change update(Change entity) {
         Objects.requireNonNull(entity);

--- a/src/main/java/com/github/checkit/dao/PublicationContextDao.java
+++ b/src/main/java/com/github/checkit/dao/PublicationContextDao.java
@@ -2,6 +2,7 @@ package com.github.checkit.dao;
 
 import com.github.checkit.exception.PersistenceException;
 import com.github.checkit.model.PublicationContext;
+import com.github.checkit.model.auxilary.AbstractChangeableContext;
 import com.github.checkit.model.auxilary.CommentTag;
 import com.github.checkit.persistence.DescriptorFactory;
 import com.github.checkit.util.TermVocabulary;
@@ -204,19 +205,19 @@ public class PublicationContextDao extends BaseDao<PublicationContext> {
     }
 
     /**
-     * Get all URI identifiers of context affected in specified publication context.
+     * Get all contexts affected in specified publication context.
      *
      * @param publicationContextUri URI identifier of publication context
      * @return list of contexts
      */
-    public List<URI> getAllAffectedContexts(URI publicationContextUri) {
+    public List<AbstractChangeableContext> getAllAffectedContexts(URI publicationContextUri) {
         Objects.requireNonNull(publicationContextUri);
         try {
             return em.createNativeQuery("SELECT DISTINCT ?ctx WHERE { "
                     + "?pc a ?type ; "
                     + "    ?hasChange ?change . "
                     + "?change ?inContext ?ctx . "
-                    + "}", URI.class)
+                    + "}", AbstractChangeableContext.class)
                 .setParameter("pc", publicationContextUri)
                 .setParameter("type", typeUri)
                 .setParameter("hasChange", URI.create(TermVocabulary.s_p_ma_zmenu))

--- a/src/main/java/com/github/checkit/dao/PublicationContextDao.java
+++ b/src/main/java/com/github/checkit/dao/PublicationContextDao.java
@@ -1,7 +1,6 @@
 package com.github.checkit.dao;
 
 import com.github.checkit.exception.PersistenceException;
-import com.github.checkit.model.ProjectContext;
 import com.github.checkit.model.PublicationContext;
 import com.github.checkit.model.auxilary.CommentTag;
 import com.github.checkit.persistence.DescriptorFactory;
@@ -206,10 +205,10 @@ public class PublicationContextDao extends BaseDao<PublicationContext> {
     /**
      * Checks if not approved publication context related to specified project exists.
      *
-     * @param projectContext Project context
+     * @param projectContextUri URI identifier of project context
      * @return if publication context exists
      */
-    public boolean exists(ProjectContext projectContext) {
+    public boolean existsNotApproved(URI projectContextUri) {
         try {
             return em.createNativeQuery("ASK { "
                     + "?pc a ?type ; "
@@ -223,7 +222,7 @@ public class PublicationContextDao extends BaseDao<PublicationContext> {
                     + "}", Boolean.class)
                 .setParameter("type", typeUri)
                 .setParameter("fromProject", URI.create(TermVocabulary.s_p_z_projektu))
-                .setParameter("project", projectContext.getUri())
+                .setParameter("project", projectContextUri)
                 .setParameter("commentType", URI.create(TermVocabulary.s_c_Comment))
                 .setParameter("hasTag", URI.create(TermVocabulary.s_p_ma_stitek))
                 .setParameter("topic", URI.create(TermVocabulary.s_p_topic))

--- a/src/main/java/com/github/checkit/dto/ReviewableVocabularyDto.java
+++ b/src/main/java/com/github/checkit/dto/ReviewableVocabularyDto.java
@@ -1,5 +1,6 @@
 package com.github.checkit.dto;
 
+import com.github.checkit.model.User;
 import com.github.checkit.model.Vocabulary;
 import java.net.URI;
 import java.util.List;
@@ -13,15 +14,18 @@ public class ReviewableVocabularyDto {
     private final boolean gestored;
     private final VocabularyStatisticsDto statistics;
     private final List<UserDto> gestors;
+    private final List<UserDto> approvedByUsers;
 
     /**
      * Constructor.
      */
-    public ReviewableVocabularyDto(Vocabulary vocabulary, boolean gestored, VocabularyStatisticsDto statistics) {
+    public ReviewableVocabularyDto(Vocabulary vocabulary, boolean gestored, VocabularyStatisticsDto statistics,
+                                   List<User> approvedBy) {
         this.uri = vocabulary.getUri();
         this.label = vocabulary.getLabel();
         this.gestored = gestored;
         this.gestors = vocabulary.getGestors().stream().map(UserDto::new).toList();
+        this.approvedByUsers = approvedBy.stream().map(UserDto::new).toList();
         this.statistics = statistics;
     }
 }

--- a/src/main/java/com/github/checkit/model/Change.java
+++ b/src/main/java/com/github/checkit/model/Change.java
@@ -136,8 +136,8 @@ public class Change extends AbstractCommentableEntity {
      */
     public boolean hasSameTripleAs(Change right) {
         Objects.requireNonNull(right);
-        return this.subject.equals(right.subject) && this.predicate.equals(right.predicate)
-            && this.object.equals(right.object);
+        return (subjectType.equals(ChangeSubjectType.BLANK_NODE) || this.subject.equals(right.subject))
+            && this.predicate.equals(right.predicate) && this.object.equals(right.object);
     }
 
     /**
@@ -171,6 +171,10 @@ public class Change extends AbstractCommentableEntity {
 
     public boolean notApproved() {
         return getApprovedBy().isEmpty();
+    }
+
+    public boolean isInBlankNode() {
+        return getSubjectType().equals(ChangeSubjectType.BLANK_NODE);
     }
 
     /**

--- a/src/main/java/com/github/checkit/service/ChangeService.java
+++ b/src/main/java/com/github/checkit/service/ChangeService.java
@@ -227,6 +227,19 @@ public class ChangeService extends BaseRepositoryService<Change> {
         }
     }
 
+    /**
+     * Finds any change in context in publication context.
+     *
+     * @param publicationContextUri URI identifier of publication context
+     * @param contextUri            URI identifier of context
+     * @return change
+     */
+    public Change findRequiredAnyInContextInPublicationContext(URI publicationContextUri, URI contextUri) {
+        return changeDao.findAnyInContextInPublicationContext(publicationContextUri, contextUri).orElseThrow(() ->
+            new NotFoundException("No changes for context \"%s\" found in publication context \"%s\".",
+                contextUri, publicationContextUri));
+    }
+
     public URI generateEntityUri() {
         return changeDao.generateEntityUri();
     }

--- a/src/main/java/com/github/checkit/service/PublicationContextService.java
+++ b/src/main/java/com/github/checkit/service/PublicationContextService.java
@@ -218,7 +218,7 @@ public class PublicationContextService extends BaseRepositoryService<Publication
 
         PublicationContext publicationContext;
         Set<User> reviewers = new HashSet<>();
-        boolean publicationContextExists = publicationContextDao.exists(project);
+        boolean publicationContextExists = publicationContextDao.existsNotApproved(project.getUri());
         if (publicationContextExists) {
             publicationContext = findRequiredFromProject(project);
             publicationContext.getChanges().forEach(change -> reviewers.addAll(change.getReviewBy()));


### PR DESCRIPTION
- Publication context detail sends users who approved vocabulary
- approvable publication calcualtion is optimized
- correction in blanknodes on repeated submissions of project

## Changed endpoint

**Publication context detail now sends list of users who approved vocabulary for each vocabulary**
GET `/publication-contexts/{publicationContextId}`
Response example with `approvedByUsers` on vocabulary:
```json
{
    "id": "instance-2105790091",
    "uri": "https://slovník.gov.cz/datový/popis-zmen/pojem/publikační-kontext/instance-2105790091",
    "label": "Datový slovník Poslanecké sněmovny Parlamentu České republiky - slovník",
    "projectContext": "https://slovník.gov.cz/datový/pracovní-prostor/pojem/metadatový-kontext/instance751653346",
    "state": "APPROVABLE",
    "statistics": {
        "totalChanges": 8,
        "reviewableChanges": 4,
        "approvedChanges": 2,
        "rejectedChanges": 0
    },
    "affectedVocabularies": [
        {
            "uri": "https://slovník.gov.cz/datový/psp",
            "label": "Datový slovník Poslanecké sněmovny Parlamentu České republiky - slovník",
            "gestored": false,
            "statistics": {
                "totalChanges": 4
            },
            "gestors": [
                {
                    "id": "5d4a90e8-01ac-4823-bd47-397840095b8c",
                    "firstName": "Filip",
                    "lastName": "Kopecký"
                }
            ],
            "approvedByUsers": [
                {
                    "id": "35348b19-aaa4-481d-b424-5de3c27d0d5b",
                    "firstName": "Admin",
                    "lastName": "Hugo"
                }
            ]
        },
        ...
    ],
    ...
}
```