### PR TITLE
Notify about gestoring requests and read all notifications

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ plugins {
 }
 
 group = 'com.github'
-version = "0.5.3"
+version = "0.5.4"
 
 compileJava {
     sourceCompatibility = '17'

--- a/src/main/java/com/github/checkit/controller/NotificationController.java
+++ b/src/main/java/com/github/checkit/controller/NotificationController.java
@@ -37,6 +37,12 @@ public class NotificationController extends BaseController {
     }
 
     @ResponseStatus(HttpStatus.NO_CONTENT)
+    @PostMapping("/unread/seen")
+    public void markAllSeen() {
+        notificationService.markAllSeen();
+    }
+
+    @ResponseStatus(HttpStatus.NO_CONTENT)
     @PostMapping("/seen")
     public void markSeen(@RequestBody URI notificationUri) {
         notificationService.markSeen(notificationUri);

--- a/src/main/java/com/github/checkit/dao/NotificationDao.java
+++ b/src/main/java/com/github/checkit/dao/NotificationDao.java
@@ -61,6 +61,32 @@ public class NotificationDao extends BaseDao<Notification> {
         }
     }
 
+    /**
+     * Finds all unread notifications for specified user.
+     *
+     * @param userUri URI identifier of user
+     */
+    public List<Notification> getAllUnreadForUser(URI userUri) {
+        Objects.requireNonNull(userUri);
+        try {
+            return em.createNativeQuery("SELECT ?n WHERE { "
+                    + "?n a ?type ;"
+                    + "   ?addressedTo ?user . "
+                    + "FILTER NOT EXISTS { "
+                    + "     ?n ?seen ?time . "
+                    + "     }"
+                    + "}", type)
+                .setParameter("type", typeUri)
+                .setParameter("addressedTo", URI.create(TermVocabulary.s_p_addressed_to))
+                .setParameter("user", userUri)
+                .setParameter("seen", URI.create(TermVocabulary.s_p_read_at))
+                .setDescriptor(descriptorFactory.notificationDescriptor())
+                .getResultList();
+        } catch (RuntimeException e) {
+            throw new PersistenceException(e);
+        }
+    }
+
     @Override
     public Optional<Notification> find(URI id) {
         Objects.requireNonNull(id);

--- a/src/main/java/com/github/checkit/service/GestoringRequestService.java
+++ b/src/main/java/com/github/checkit/service/GestoringRequestService.java
@@ -24,15 +24,17 @@ public class GestoringRequestService extends BaseRepositoryService<GestoringRequ
     private final GestoringRequestDao gestoringRequestDao;
     private final UserService userService;
     private final VocabularyService vocabularyService;
+    private final NotificationService notificationService;
 
     /**
      * Constructor.
      */
     public GestoringRequestService(GestoringRequestDao gestoringRequestDao, UserService userService,
-                                   VocabularyService vocabularyService) {
+                                   VocabularyService vocabularyService, NotificationService notificationService) {
         this.gestoringRequestDao = gestoringRequestDao;
         this.userService = userService;
         this.vocabularyService = vocabularyService;
+        this.notificationService = notificationService;
     }
 
     @Override
@@ -86,7 +88,9 @@ public class GestoringRequestService extends BaseRepositoryService<GestoringRequ
             throw new AlreadyExistsException("Gestoring request from user \"%s\" to vocabulary \"%s\" already exists.",
                 applicant.getFullName(), vocabulary.getLabel());
         }
-        persist(new GestoringRequest(applicant, vocabulary));
+        GestoringRequest gestoringRequest = new GestoringRequest(applicant, vocabulary);
+        persist(gestoringRequest);
+        notificationService.createdGestoringRequest(gestoringRequest);
         logger.info("Gestoring request from user \"{}\" to vocabulary \"{}\" was created.", applicant.toSimpleString(),
             vocabulary.getUri());
     }
@@ -108,6 +112,7 @@ public class GestoringRequestService extends BaseRepositoryService<GestoringRequ
             vocabularyService.update(vocabulary);
         }
         remove(gestoringRequest);
+        notificationService.resolvedGestoringRequest(gestoringRequest, approved);
         logger.info("Gestoring request \"{}\" from user \"{}\" to vocabulary \"{}\" was {}.",
             gestoringRequest.getUri(), applicant.toSimpleString(), vocabulary.getUri(),
             approved ? "approved" : "rejected");

--- a/src/main/java/com/github/checkit/service/NotificationService.java
+++ b/src/main/java/com/github/checkit/service/NotificationService.java
@@ -99,6 +99,19 @@ public class NotificationService extends BaseRepositoryService<Notification> {
     }
 
     /**
+     * Marks all unread notification of current user as read.
+     */
+    @Transactional
+    public void markAllSeen() {
+        User current = userService.getCurrent();
+        for (Notification notification : notificationDao.getAllUnreadForUser(current.getUri())) {
+            notification.markRead();
+            update(notification);
+        }
+        logger.debug("All unread notifications for user {} were marked as seen.", current.toSimpleString());
+    }
+
+    /**
      * Creates notifications for gestors about new publication context.
      *
      * @param publicationContext created publication context

--- a/src/main/java/com/github/checkit/util/FrontendPaths.java
+++ b/src/main/java/com/github/checkit/util/FrontendPaths.java
@@ -1,7 +1,5 @@
 package com.github.checkit.util;
 
-import java.net.URI;
-
 /**
  * This class contains some URL paths of Frontend CheckIt used in notifications.
  */
@@ -9,6 +7,7 @@ public final class FrontendPaths {
 
     private static final String PUBLICATION_CONTEXT_PATH_NAME = "publications";
     private static final String VOCABULARY_IN_PUBLICATION_CONTEXT_PATH_NAME = "vocabulary";
+    private static final String ADMIN_PANEL_PATH_NAME = "administration";
 
     private static final String VOCABULARY_URI_PARAMETER_NAME = "vocabularyUri";
     private static final String CHANGE_ID_PARAMETER_NAME = "changeId";
@@ -26,5 +25,9 @@ public final class FrontendPaths {
                                                                        String changeId) {
         return String.format("%s&%s=%s", getVocabularyInPublicationContextPath(publicationId, vocabularyUri),
             CHANGE_ID_PARAMETER_NAME, changeId);
+    }
+
+    public static String getGestoringRequests() {
+        return String.format("/%s", ADMIN_PANEL_PATH_NAME);
     }
 }

--- a/src/main/java/com/github/checkit/util/NotificationTemplateUtil.java
+++ b/src/main/java/com/github/checkit/util/NotificationTemplateUtil.java
@@ -4,6 +4,8 @@ import com.github.checkit.model.Change;
 import com.github.checkit.model.Comment;
 import com.github.checkit.model.Notification;
 import com.github.checkit.model.PublicationContext;
+import com.github.checkit.model.User;
+import com.github.checkit.model.Vocabulary;
 import cz.cvut.kbss.jopa.model.MultilingualString;
 
 public final class NotificationTemplateUtil {
@@ -125,7 +127,7 @@ public final class NotificationTemplateUtil {
      * @return Notification template
      */
     public static Notification getForApprovingCommentOnPublicationContext(Comment comment,
-                                                                        PublicationContext pc) {
+                                                                          PublicationContext pc) {
         Notification notification = new Notification();
         notification.setTitle(
             new MultilingualString().set("en", "Publication context approved").set("cs", "Publikační kontext "
@@ -148,7 +150,7 @@ public final class NotificationTemplateUtil {
      * @return Notification template
      */
     public static Notification getForRejectionCommentOnPublicationContext(Comment comment,
-                                                                        PublicationContext pc) {
+                                                                          PublicationContext pc) {
         Notification notification = new Notification();
         notification.setTitle(
             new MultilingualString().set("en", "Publication context rejected").set("cs", "Publikační kontext "
@@ -160,6 +162,51 @@ public final class NotificationTemplateUtil {
                 String.format("%s zamítnul publikační kontext \"%s\", na kterém jste se podílel/a.",
                     comment.getAuthor().getFullName(), pc.getFromProject().getLabel())));
         notification.setAbout(FrontendPaths.getPublicationDetailPath(pc.getId()));
+        return notification;
+    }
+
+    /**
+     * Creates template for created gestoring request.
+     *
+     * @param applicant  user applying to gestor
+     * @param vocabulary vocabulary
+     * @return Notification template
+     */
+    public static Notification getForCreatedGestoringRequest(User applicant, Vocabulary vocabulary) {
+        Notification notification = new Notification();
+        notification.setTitle(
+            new MultilingualString().set("en", "New gestoring request").set("cs", "Nový požadavek na gestorování"));
+        notification.setContent(new MultilingualString().set("en",
+                String.format("%s requests to gestor vocabulary \"%s\".",
+                    applicant.getFullName(), vocabulary.getLabel()))
+            .set("cs",
+                String.format("%s žádá o gestorování slovníku \"%s\".",
+                    applicant.getFullName(), vocabulary.getLabel())));
+        notification.setAbout(FrontendPaths.getGestoringRequests());
+        return notification;
+    }
+
+    /**
+     * Creates template for resolved gestoring request.
+     *
+     * @param vocabulary vocabulary
+     * @param approved   if gestoring request was approved or not
+     * @return Notification template
+     */
+    public static Notification getForResolvedGestoringRequest(Vocabulary vocabulary, boolean approved) {
+        Notification notification = new Notification();
+        notification.setTitle(
+            new MultilingualString().set("en", "Resolved gestoring request").set("cs", "Vyřízený požadavek na "
+                + "gestorování"));
+        notification.setContent(new MultilingualString().set("en",
+                String.format("Your gestoring request for vocabulary \"%s\" was %s",
+                    vocabulary.getLabel(), approved ? "approved. You can now review changes made to this vocabulary." :
+                                           "rejected."))
+            .set("cs",
+                String.format("Vaše žádost o gestorování slovníku \"%s\" byla %s",
+                    vocabulary.getLabel(), approved ? "schválena. Nyní můžete revidovat změny provedené pro tento "
+                        + "slovník." : "zamítnuta.")));
+        notification.setAbout("");
         return notification;
     }
 }

--- a/src/main/java/com/github/checkit/util/NotificationTemplateUtil.java
+++ b/src/main/java/com/github/checkit/util/NotificationTemplateUtil.java
@@ -206,7 +206,7 @@ public final class NotificationTemplateUtil {
                 String.format("Vaše žádost o gestorování slovníku \"%s\" byla %s",
                     vocabulary.getLabel(), approved ? "schválena. Nyní můžete revidovat změny provedené pro tento "
                         + "slovník." : "zamítnuta.")));
-        notification.setAbout("");
+        notification.setAbout(null);
         return notification;
     }
 }


### PR DESCRIPTION
- Send notifications about new and resolved gestoring requests
- Endpoint to mark all unread notifications as read

## New endpoint

**Endpoint to mark all unread notifications as read**
POST `/notifications/unread/seen`
Returns 204 NO CONTENT